### PR TITLE
Ledger: Add support for live derivation path

### DIFF
--- a/main/signers/ledger/Ledger/index.js
+++ b/main/signers/ledger/Ledger/index.js
@@ -68,9 +68,10 @@ class Ledger extends Signer {
     try {
       let transport = new TransportNodeHid(new HID.HID(this.devicePath))
       let eth = new Eth(transport)
-      eth.getAddress(this.getPath(this.index), display, true).then(result => {
+      eth.getAddress(this.basePath(), display, true).then(result => {
         transport.close()
-        let address = result.address.toLowerCase()
+        let all = this.deriveHDAccounts(result.publicKey, result.chainCode)
+        let address = all[this.index].toLowerCase()
         let current = this.accounts[this.index].toLowerCase()
         if (address !== current) {
           // TODO: Error Notification


### PR DESCRIPTION
You've discussed ([here](https://github.com/floating/frame/issues/124)) adding the "Ledger Live" derivation path in the future. I went ahead and updated the derivation path myself to be able to use the "Legder Live account" and got stuck with this check [`if (address !== current)`](https://github.com/floating/frame/blob/master/main/signers/ledger/Ledger/index.js#L75)

I reviewed the way you [`lookupAccounts`](https://github.com/floating/frame/blob/master/main/signers/ledger/Ledger/index.js#L110) and followed the same approach to get it working. I'm on unknown territory here so let me know if this makes sense.