### PR TITLE
Final touches before audit

### DIFF
--- a/main/accounts/Account/index.js
+++ b/main/accounts/Account/index.js
@@ -117,6 +117,7 @@ class Account {
     console.log('Account close needs to remove observers')
   }
   signMessage (message, cb) {
+    if (!message) return cb(new Error('No message to sign'))
     if (this.signer) {
       signers.get(this.signer.id).signMessage(this.index, message, cb)
     } else if (this.smart) {

--- a/main/signers/hot/SeedSigner/index.js
+++ b/main/signers/hot/SeedSigner/index.js
@@ -27,6 +27,7 @@ class SeedSigner extends HotSigner {
       // Update signer
       this.encryptedSeed = encryptedSeed
       this.addresses = addresses
+      this.update()
 
       cb(null)
     })
@@ -48,7 +49,6 @@ class SeedSigner extends HotSigner {
   unlock (password, cb) {
     super.unlock(password, { encryptedSeed: this.encryptedSeed }, cb)
   }
-
 }
 
 module.exports = SeedSigner

--- a/main/signers/hot/SeedSigner/index.js
+++ b/main/signers/hot/SeedSigner/index.js
@@ -10,7 +10,7 @@ class SeedSigner extends HotSigner {
     super(signer, WORKER_PATH)
     this.encryptedSeed = (signer && signer.encryptedSeed)
     this.type = 'seed'
-    this.update()
+    if (this.encryptedSeed) this.update()
   }
 
   addSeed (seed, password, cb) {

--- a/main/signers/hot/index.js
+++ b/main/signers/hot/index.js
@@ -20,7 +20,10 @@ module.exports = {
     if (!password) return cb(new Error('Password required to create hot signer'))
     const signer = new SeedSigner()
     signer.addSeed(seed, password, (err, result) => {
-      if (err) return cb(err)
+      if (err) {
+        signer.close()
+        return cb(err)
+      }
       signers.add(signer)
       cb(null, signer)
     })
@@ -30,7 +33,10 @@ module.exports = {
     if (!password) return cb(new Error('Password required to create hot signer'))
     const signer = new SeedSigner()
     signer.addPhrase(phrase, password, (err, result) => {
-      if (err) return cb(err)
+      if (err) {
+        signer.close()
+        return cb(err)
+      }
       signers.add(signer)
       cb(null, signer)
     })
@@ -40,7 +46,10 @@ module.exports = {
     if (!password) return cb(new Error('Password required to create hot signer'))
     const signer = new RingSigner()
     signer.addPrivateKey(privateKey, password, (err, result) => {
-      if (err) return cb(err)
+      if (err) {
+        signer.close()
+        return cb(err)
+      }
       signers.add(signer)
       cb(null, signer)
     })
@@ -49,9 +58,12 @@ module.exports = {
     if (!keystore) return cb(new Error('Keystore required'))
     if (!keystorePassword) return cb(new Error('Keystore password required'))
     if (!password) return cb(new Error('Signer password required'))
-    const signer = new RingSigner({ type: 'ring' })
+    const signer = new RingSigner()
     signer.addKeystore(keystore, keystorePassword, password, (err, result) => {
-      if (err) return cb(err)
+      if (err) {
+        signer.close()
+        return cb(err)
+      }
       signers.add(signer)
       cb(null, signer)
     })

--- a/main/signers/hot/index.js
+++ b/main/signers/hot/index.js
@@ -16,6 +16,8 @@ module.exports = {
     cb(null, bip39.generateMnemonic())
   },
   createFromSeed: (signers, seed, password, cb) => {
+    if (!seed) return cb(new Error('Seed required to create hot signer'))
+    if (!password) return cb(new Error('Password required to create hot signer'))
     const signer = new SeedSigner()
     signer.addSeed(seed, password, (err, result) => {
       if (err) return cb(err)
@@ -24,6 +26,8 @@ module.exports = {
     })
   },
   createFromPhrase: (signers, phrase, password, cb) => {
+    if (!phrase) return cb(new Error('Phrase required to create hot signer'))
+    if (!password) return cb(new Error('Password required to create hot signer'))
     const signer = new SeedSigner()
     signer.addPhrase(phrase, password, (err, result) => {
       if (err) return cb(err)
@@ -32,8 +36,8 @@ module.exports = {
     })
   },
   createFromPrivateKey: (signers, privateKey, password, cb) => {
-    if (!privateKey) return cb(new Error('Private key required to create local signer'))
-    if (!password) return cb(new Error('Password required to create local signer'))
+    if (!privateKey) return cb(new Error('Private key required to create hot signer'))
+    if (!password) return cb(new Error('Password required to create hot signer'))
     const signer = new RingSigner()
     signer.addPrivateKey(privateKey, password, (err, result) => {
       if (err) return cb(err)

--- a/main/signers/index.js
+++ b/main/signers/index.js
@@ -21,7 +21,6 @@ class Signers extends EventEmitter {
       signer.close()
       // If hot signer -> erase from disk
       if (signer.delete) signer.delete()
-      this.signers[index].delete()
       this.signers.splice(index, 1)
     }
   }

--- a/test/signers/ring.test.js
+++ b/test/signers/ring.test.js
@@ -123,12 +123,13 @@ describe('Ring signer', () => {
       gasPrice: '0x09184e72a000',
       gasLimit: '0x30000',
       to: '0xfa3caabc8eefec2b5e2895e5afbf79379e7268a7',
-      value: '0x00'
+      value: '0x0'
     }
 
     signer.signTransaction(0, rawTx, (err, result) => {
       expect(err).toBe(null)
       expect(result.length).not.toBe(0)
+      expect(result.slice(0, 2)).toBe('0x')
       done()
     })
   })

--- a/test/signers/ring.test.js
+++ b/test/signers/ring.test.js
@@ -20,6 +20,24 @@ describe('Ring signer', () => {
   beforeAll(clean)
   afterAll(clean)
 
+  test('Create from invalid private key', (done) => {
+    const privateKey = 'invalid key'
+    hot.createFromPrivateKey(signers, privateKey, PASSWORD, (err, result) => {
+      expect(err).not.toBe(null)
+      expect(store(`main.signers`)).toEqual({})
+      done()
+    })
+  })
+
+  test('Create from invalid keystore key', (done) => {
+    const keystore = { invalid: 'keystore' }
+    hot.createFromKeystore(signers, keystore, 'test', PASSWORD, (err, result) => {
+      expect(err).not.toBe(null)
+      expect(store(`main.signers`)).toEqual({})
+      done()
+    })
+  })
+
   test('Create from private key', (done) => {
     const privateKey = crypto.randomBytes(32).toString('hex')
     hot.createFromPrivateKey(signers, privateKey, PASSWORD, (err, result) => {

--- a/test/signers/seed.test.js
+++ b/test/signers/seed.test.js
@@ -63,12 +63,13 @@ describe('Seed signer', () => {
       gasPrice: '0x09184e72a000',
       gasLimit: '0x30000',
       to: '0xfa3caabc8eefec2b5e2895e5afbf79379e7268a7',
-      value: '0x00'
+      value: '0x0'
     }
 
     signer.signTransaction(0, rawTx, (err, result) => {
       expect(err).toBe(null)
       expect(result.length).not.toBe(0)
+      expect(result.slice(0, 2)).toBe('0x')
       done()
     })
   })

--- a/test/signers/seed.test.js
+++ b/test/signers/seed.test.js
@@ -14,6 +14,15 @@ describe('Seed signer', () => {
   beforeAll(clean)
   afterAll(clean)
 
+  test('Create from invalid phrase', (done) => {
+    const mnemonic = 'invalid mnemonic'
+    hot.createFromPhrase(signers, mnemonic, PASSWORD, (err, result) => {
+      expect(err).not.toBe(null)
+      expect(store(`main.signers`)).toEqual({})
+      done()
+    })
+  })
+
   test('Create from phrase', (done) => {
     const mnemonic = bip39.generateMnemonic()
     hot.createFromPhrase(signers, mnemonic, PASSWORD, (err, result) => {


### PR DESCRIPTION
This PR
1) fixes a bug related to removing signers
2) adds payload validation to methods `account.signMessage` and `account.signTransaction`
3) adds more validation to creation of hot signers (e.g. valid private key)
4) makes sure hot signers aren't added to store/written to disk until a seed or key is added
5) makes sure hot signer workers are closed if an error occurs during the creation phase (to prevent "orphaned" child processes)