### PR TITLE
Fixes EPIPE error and signer tests

### DIFF
--- a/main/accounts/aragon/index.js
+++ b/main/accounts/aragon/index.js
@@ -86,6 +86,8 @@ class Aragon {
 
   pathTransaction (tx, cb) {
     if (!this.wrap) return cb(new Error('Aragon wrapper not ready'))
+    tx.value = tx.value || '0x'
+    tx.data = tx.data || '0x'
     this.wrap.calculateTransactionPath(this.actor.address, this.agent, 'execute', [tx.to, tx.value, tx.data]).then(result => {
       var newTx = result[0]
       delete newTx.nonce

--- a/main/signers/Signer/index.js
+++ b/main/signers/Signer/index.js
@@ -4,11 +4,12 @@
 // const deriveHDAccounts = require('worker-farm')(require.resolve('./derive'))
 const log = require('electron-log')
 const deriveHDAccounts = require('./derive')
-
+const EventEmitter = require('events')
 const crypt = require('../../crypt')
 
-class Signer {
+class Signer extends EventEmitter {
   constructor () {
+    super()
     this.addresses = []
     this.index = 0
     this.requests = {}

--- a/main/signers/hot/HotSigner/index.js
+++ b/main/signers/hot/HotSigner/index.js
@@ -27,6 +27,7 @@ class HotSigner extends Signer {
     }
     this._worker = fork(workerPath)
     this._getToken()
+    this.ready = false
   }
 
   save (data) {
@@ -73,7 +74,7 @@ class HotSigner extends Signer {
   }
 
   close () {
-    this._worker.disconnect()
+    if (!this.ready) this.once('ready', () => this._worker.disconnect())
     store.removeSigner(this.id)
     log.info('Signer closed')
   }
@@ -150,6 +151,8 @@ class HotSigner extends Signer {
       if (type === 'token') {
         this._token = token
         this._worker.removeListener('message', listener)
+        this.ready = true
+        this.emit('ready')
       }
     }
     this._worker.addListener('message', listener)

--- a/main/signers/hot/HotSigner/index.js
+++ b/main/signers/hot/HotSigner/index.js
@@ -6,12 +6,12 @@ const { app } = require('electron')
 const log = require('electron-log')
 const uuid = require('uuid/v4')
 
-const store = require('../../../store')
-// Mock windows module if running tests
-const windows = app ? require('../../../windows') : { broadcast: () => {} }
 const Signer = require('../../Signer')
-
-const USER_DATA = app ? app.getPath('userData') : './test/.userData'
+const store = require('../../../store')
+// Mock windows module during tests
+const windows = app ? require('../../../windows') : { broadcast: () => {} }
+// Mock user data dir during tests
+const USER_DATA = app ? app.getPath('userData') : path.resolve(path.dirname(require.main.filename), '../.userData')
 const SIGNERS_PATH = path.resolve(USER_DATA, 'signers')
 
 class HotSigner extends Signer {

--- a/main/signers/hot/HotSigner/index.js
+++ b/main/signers/hot/HotSigner/index.js
@@ -74,7 +74,8 @@ class HotSigner extends Signer {
   }
 
   close () {
-    if (!this.ready) this.once('ready', () => this._worker.disconnect())
+    if (this.ready) this._worker.disconnect()
+    else this.once('ready', () => this._worker.disconnect())
     store.removeSigner(this.id)
     log.info('Signer closed')
   }

--- a/test/signers/ring.test.js
+++ b/test/signers/ring.test.js
@@ -1,18 +1,19 @@
 const crypto = require('crypto')
 const fs = require('fs')
+const { remove } = require('fs-extra')
 const path = require('path')
 
 const hot = require('../../main/signers/hot')
-const { clean } = require('../util')
 const store = require('../../main/store')
 
 const PASSWORD = 'fr@///3_password'
+const SIGNER_PATH = path.resolve(__dirname, '../.userData/signers')
 const FILE_PATH = path.resolve(__dirname, 'keystore.json')
 
 // Stubs
-const signers = {
-  add: (signer) => {}
-}
+const signers = { add: () => {} }
+// Util
+const clean = () => remove(SIGNER_PATH)
 
 describe('Ring signer', () => {
   let signer

--- a/test/signers/seed.test.js
+++ b/test/signers/seed.test.js
@@ -1,12 +1,16 @@
 const bip39 = require('bip39')
 const hot = require('../../main/signers/hot')
-const { clean } = require('../util')
+const { remove } = require('fs-extra')
+const path = require('path')
 const store = require('../../main/store')
 
 const PASSWORD = 'fr@///3_password'
+const SIGNER_PATH = path.resolve(__dirname, '../.userData/signers')
 
 // Stubs
-const signers = { add: (signer) => {} }
+const signers = { add: () => {} }
+// Util
+const clean = () => remove(SIGNER_PATH)
 
 describe('Seed signer', () => {
   let signer

--- a/test/util.js
+++ b/test/util.js
@@ -39,9 +39,4 @@ class Counter {
   }
 }
 
-const clean = () => {
-  const userData = path.resolve('./test/.userData')
-  emptyDirSync(userData)
-}
-
-module.exports = { Counter, Observer, clean }
+module.exports = { Counter, Observer }


### PR DESCRIPTION
Fixes `EPIPE` error on Windows when disconnecting from a signer child process and fixes signer tests.