### PR TITLE
Smart account signed messages

### DIFF
--- a/main/accounts/Account/index.js
+++ b/main/accounts/Account/index.js
@@ -185,7 +185,7 @@ class Account {
       signers.get(this.signer.id).signMessage(this.index, message, cb)
     } else if (this.smart) {
       if (this.smart.actor && this.smart.actor.account && this.smart.actor.account.signer) {
-        signers.get(this.smart.actor.account.id).signMessage(this.index, message, cb)
+        signers.get(this.smart.actor.account.id).signMessage(this.index, message, this.aragon.processSignedMessage(cb))
       } else {
         cb(new Error(`Agent's (${this.smart.agent}) signer is not ready`))
       }

--- a/main/accounts/Account/index.js
+++ b/main/accounts/Account/index.js
@@ -201,7 +201,7 @@ class Account {
       signers.get(this.signer.id).signTypedData(this.index, typedData, cb)
     } else if (this.smart) {
       if (this.smart.actor && this.smart.actor.account && this.smart.actor.account.signer) {
-        signers.get(this.smart.actor.account.id).signTypedData(this.index, typedData, cb)
+        signers.get(this.smart.actor.account.id).signTypedData(this.index, typedData, this.aragon.processSignedMessage(cb))
       } else {
         cb(new Error(`Agent's (${this.smart.agent}) signer is not ready`))
       }

--- a/main/accounts/aragon/index.js
+++ b/main/accounts/aragon/index.js
@@ -130,6 +130,13 @@ class Aragon {
       }).catch(cb)
     })
   }
+
+  processSignedMessage (cb) {
+    return (err,msg) => {
+      if(err) return cb(err)
+      return cb(err,"0x01" + msg.substring(2))
+    }
+  } 
 }
 
 module.exports = { Aragon, resolveName }

--- a/main/provider/index.js
+++ b/main/provider/index.js
@@ -112,6 +112,8 @@ class Provider extends EventEmitter {
   verifySignature (signed, message, address, cb) {
     this.getSignedAddress(signed, message, (err, verifiedAddress) => {
       if (err) return cb(err)
+        console.log(verifiedAddress.toLowerCase())
+        console.log(address.toLowerCase())
       if (verifiedAddress.toLowerCase() !== address.toLowerCase()) return cb(new Error(`Frame verifySignature: Failed ecRecover check`))
       cb(null, true)
     })
@@ -130,15 +132,8 @@ class Provider extends EventEmitter {
         this.resError(err.message, payload, res)
         cb(err.message)
       } else {
-        this.verifySignature(signed, message, address, (err, success) => {
-          if (err) {
-            this.resError(err.message, payload, res)
-            cb(err.message)
-          } else {
-            res({ id: payload.id, jsonrpc: payload.jsonrpc, result: signed })
-            cb(null, signed)
-          }
-        })
+        res({ id: payload.id, jsonrpc: payload.jsonrpc, result: signed })
+        cb(null, signed)
       }
     })
   }
@@ -156,15 +151,8 @@ class Provider extends EventEmitter {
         this.resError(err.message, payload, res)
         cb(err.message)
       } else {
-        const recoveredAddress = recoverTypedData(typedData, signed)
-        if (recoveredAddress.toLowerCase() !== address.toLowerCase()) {
-          const err = new Error('TypedData signature verification failed')
-          this.resError(err.message, { ...payload, recoveredAddress }, res)
-          cb(err.message)
-        } else {
-          res({ id: payload.id, jsonrpc: payload.jsonrpc, result: signed })
-          cb(null, signed)
-        }
+        res({ id: payload.id, jsonrpc: payload.jsonrpc, result: signed })
+        cb(null, signed)
       }
     })
   }

--- a/main/provider/index.js
+++ b/main/provider/index.js
@@ -112,8 +112,6 @@ class Provider extends EventEmitter {
   verifySignature (signed, message, address, cb) {
     this.getSignedAddress(signed, message, (err, verifiedAddress) => {
       if (err) return cb(err)
-        console.log(verifiedAddress.toLowerCase())
-        console.log(address.toLowerCase())
       if (verifiedAddress.toLowerCase() !== address.toLowerCase()) return cb(new Error(`Frame verifySignature: Failed ecRecover check`))
       cb(null, true)
     })


### PR DESCRIPTION
Smart accounts need to be validated differently from regular accounts, so this validation if it needs to exist should be in the signer. 

I'm not sure it even needs to exist though because it will be validated by the client anyway, and should only fail locally if there is a bug in the signer.