### PR TITLE
support EIP-1559 on all custom chains

### DIFF
--- a/main/chains/index.js
+++ b/main/chains/index.js
@@ -2,6 +2,7 @@
 
 const EventEmitter = require('events')
 const { addHexPrefix } = require('ethereumjs-util')
+const { Hardfork } = require('@ethereumjs/common')
 const provider = require('eth-provider')
 const log = require('electron-log')
 
@@ -59,6 +60,12 @@ class ChainConnection extends EventEmitter {
     monitor.on('data', block => {
       if ('baseFeePerGas' in block) {
         this.chainConfig.setHardforkByBlockNumber(block.number)
+
+        if (!this.chainConfig.gteHardfork(Hardfork.London)) {
+          // if baseFeePerGas is present in the block header, the hardfork
+          // must be at least London
+          this.chainConfig.setHardfork(Hardfork.London)
+        }
       }
 
       const gasCalculator = new GasCalculator(provider)


### PR DESCRIPTION
Previously this check was falling back to the known configuration in the ethereumjs/common library, which didn't exist for certain custom chains. This fixes EIP-1559 for any chain that doesn't ship with a common configuration, including but not limited to Arbitrum, Optimism, Avalanche and xDai.