### PR TITLE
Handle invalid typed data on Ledger and hot signers

### DIFF
--- a/main/signers/hot/HotSigner/worker.js
+++ b/main/signers/hot/HotSigner/worker.js
@@ -57,8 +57,12 @@ class HotSignerWorker {
   }
 
   signTypedData (key, params, pseudoCallback) {
-    const signature = ethSigUtil.signTypedMessage(key, { data: params.typedData }, params.version)
-    pseudoCallback(null, signature)
+    try {
+      const signature = ethSigUtil.signTypedMessage(key, { data: params.typedData }, params.version)
+      pseudoCallback(null, signature)
+    } catch (e) {
+      pseudoCallback(e.message)
+    }
   }
 
   signTransaction (key, rawTx, pseudoCallback) {

--- a/main/signers/ledger/Ledger/eth.ts
+++ b/main/signers/ledger/Ledger/eth.ts
@@ -49,9 +49,15 @@ export default class LedgerEthereumApp {
   }
 
   async signTypedData (path: string, typedData: TypedMessage<any>) {
-    const { domain, types, primaryType, message } = TypedDataUtils.sanitizeData(typedData)
-    const domainSeparatorHex = TypedDataUtils.hashStruct('EIP712Domain', domain, types).toString('hex')
-    const hashStructMessageHex = TypedDataUtils.hashStruct(primaryType as string, message, types).toString('hex')
+    let domainSeparatorHex, hashStructMessageHex
+
+    try {
+      const { domain, types, primaryType, message } = TypedDataUtils.sanitizeData(typedData)
+      domainSeparatorHex = TypedDataUtils.hashStruct('EIP712Domain', domain, types).toString('hex')
+      hashStructMessageHex = TypedDataUtils.hashStruct(primaryType as string, message, types).toString('hex')
+    } catch (e) {
+      throw { statusCode: 99901, message: 'Invalid typed data' }
+    }
 
     const signature = await this.eth.signEIP712HashedMessage(path, domainSeparatorHex, hashStructMessageHex)
     const hashedSignature = signature.r + signature.s + padToEven((signature.v - 27).toString(16))

--- a/main/signers/ledger/Ledger/index.ts
+++ b/main/signers/ledger/Ledger/index.ts
@@ -38,6 +38,11 @@ interface Address {
 function wasRequestRejected(err: DeviceError) {
   return [27013].includes(err.statusCode)
 }
+
+function isInvalidRequest(err: DeviceError) {
+  return [99901].includes(err.statusCode)
+}
+
 function isDeviceAsleep (err: DeviceError) {
   return [27404, 26628].includes(err.statusCode)
 }
@@ -58,7 +63,7 @@ function getStatusForError (err: DeviceError) {
     return Status.LOCKED
   }
 
-  if (wasRequestRejected(err)) {
+  if (wasRequestRejected(err) || isInvalidRequest(err)) {
     return Status.OK
   }
 
@@ -439,10 +444,10 @@ export default class Ledger extends Signer {
           cb(null, signedData)
         } catch (e) {
           const err = e as DeviceError
-          const message = wasRequestRejected(err) ? 'Sign request rejected by user' : 'Sign message error'
+          const message = wasRequestRejected(err) ? 'Sign request rejected by user' : `Sign message error: ${err.message}`
 
           this.handleError(err)
-          log.error('error signing typed data on Ledger', err.toString())
+          log.error('error signing typed data on Ledger', message)
 
           cb(new Error(message), undefined)
         }

--- a/test/main/signers/ledger/Ledger/index.test.js
+++ b/test/main/signers/ledger/Ledger/index.test.js
@@ -444,6 +444,23 @@ describe('#signTypedData', () => {
     runNextRequest()
   })
 
+  it('fails if the signing request is invalid', done => {
+    Eth.mock.instances[0].signTypedData.mockRejectedValue({ statusCode: 99901, message: 'Invalid typed data' })
+
+    ledger.once('update', () => done('Ledger unexpectedly updated!'))
+    ledger.once('close', () => done('Ledger unexpectedly closed!'))
+
+    ledger.signTypedData(5, 'V4', 'typed data', (err, signature) => {
+      verifyDone(done, () => {
+        expect(ledger.status).toBe(Status.OK)
+        expect(signature).toBeUndefined()
+        expect(err.message).toMatch(/Sign message error/)
+      })
+    })
+
+    runNextRequest()
+  })
+
   const errorCases = [
     {
       testCase: 'there is a communication error',
@@ -473,7 +490,7 @@ describe('#signTypedData', () => {
         ledger.signTypedData(5, 'V4', 'typed data', (err, signature) => {
           verifyPromise(resolve, reject, () => {
             expect(signature).toBeUndefined()
-            expect(err.message).toBe('Sign message error')
+            expect(err.message).toMatch(/Sign message error/)
           })
         })
       })


### PR DESCRIPTION
Frame will now recover gracefully if the user attempts to sign typed data that is malformed or otherwise invalid.