### PR TITLE
handle undefined current account crash

### DIFF
--- a/main/accounts/index.js
+++ b/main/accounts/index.js
@@ -364,6 +364,12 @@ class Accounts extends EventEmitter {
   setSigner (id, cb) {
     this._current = id
     const currentAccount = this.current()
+
+    if (!currentAccount) {
+      console.trace(`no current account with id: ${id}`)
+      return cb(new Error('could not set signer'))
+    }
+
     const summary = currentAccount.summary()
     cb(null, summary)
     windows.broadcast('main:action', 'setSigner', summary)

--- a/main/accounts/index.js
+++ b/main/accounts/index.js
@@ -366,8 +366,10 @@ class Accounts extends EventEmitter {
     const currentAccount = this.current()
 
     if (!currentAccount) {
-      console.trace(`no current account with id: ${id}`)
-      return cb(new Error('could not set signer'))
+      const err = new Error('could not set signer')
+      log.error(`no current account with id: ${id}`, err.stack)
+
+      return cb(err)
     }
 
     const summary = currentAccount.summary()


### PR DESCRIPTION
This will prevent a crash from happening but doesn't identify the source of the issue. Added some extra logging to hopefully pin it down.