### PR TITLE
handle breaking change by Trezor Connect

### DIFF
--- a/app/flex/trezor/index.js
+++ b/app/flex/trezor/index.js
@@ -99,8 +99,8 @@ class Device {
     }).catch(err => cb(err))
   }
 
-  ethereumSignTypedHash (path, domainSeparatorHash, messageHash, cb) {
-    TrezorConnect.ethereumSignTypedData({ device: this.device, path, domain_separator_hash: domainSeparatorHash, message_hash: messageHash }).then(res => {
+  ethereumSignTypedHash (path, data, domainSeparatorHash, messageHash, cb) {
+    TrezorConnect.ethereumSignTypedData({ device: this.device, path, data, domain_separator_hash: domainSeparatorHash, message_hash: messageHash, metamask_v4_compat: true }).then(res => {
       if (!res.success) return cb(new Error(res.payload.error))
       cb(null, res.payload)
     }).catch(err => cb(err))
@@ -210,9 +210,9 @@ class Trezor {
     this.devices[id].ethereumSignTypedData(path, message, cb)
   }
 
-  ethereumSignTypedHash (id, path, domainSeparatorHash, messageHash, cb) {
+  ethereumSignTypedHash (id, path, data, domainSeparatorHash, messageHash, cb) {
     if (!this.devices[id]) return this.deviceNotFound(id, cb)
-    this.devices[id].ethereumSignTypedHash(path, domainSeparatorHash, messageHash, cb)
+    this.devices[id].ethereumSignTypedHash(path, data, domainSeparatorHash, messageHash, cb)
   }
 
   ethereumVerifyMessage (id, path, message, cb) {

--- a/main/signers/trezor/Trezor/index.ts
+++ b/main/signers/trezor/Trezor/index.ts
@@ -263,7 +263,7 @@ export default class Trezor extends Signer {
       const domainSeparatorHash = TypedDataUtils.hashStruct('EIP712Domain', domain, types, true).toString('hex')
       const messageHash = TypedDataUtils.hashStruct(primaryType as any, message, types, true).toString('hex')
 
-      flex.rpc('trezor.ethereumSignTypedHash', this.device.path, this.getPath(index), domainSeparatorHash, messageHash, rpcCallback)
+      flex.rpc('trezor.ethereumSignTypedHash', this.device.path, this.getPath(index), typedData, domainSeparatorHash, messageHash, rpcCallback)
     } else {
       flex.rpc('trezor.ethereumSignTypedData', this.device.path, this.getPath(index), typedData, rpcCallback)
     }

--- a/package-lock.json
+++ b/package-lock.json
@@ -5,7 +5,6 @@
   "requires": true,
   "packages": {
     "": {
-      "name": "frame",
       "version": "0.5.0-beta.13",
       "hasInstallScript": true,
       "license": "GPL-3.0",
@@ -50,7 +49,7 @@
         "react-restore": "0.5.0",
         "react-transition-group": "4.4.2",
         "semver": "7.3.5",
-        "trezor-connect": "8.2.6",
+        "trezor-connect": "8.2.7",
         "uuid": "8.3.2",
         "web3-utils": "1.7.0",
         "ws": "8.5.0",
@@ -38152,12 +38151,12 @@
       }
     },
     "node_modules/trezor-connect": {
-      "version": "8.2.6",
-      "resolved": "https://registry.npmjs.org/trezor-connect/-/trezor-connect-8.2.6.tgz",
-      "integrity": "sha512-ioa/NkwtFHY94VI95q4JPdoDU3HaQFFIqdS47751zHa5q8qVBzwf5vgUrNS+q3vJ2ZNE7mTk/r4FjURtDB1xjA==",
+      "version": "8.2.7",
+      "resolved": "https://registry.npmjs.org/trezor-connect/-/trezor-connect-8.2.7.tgz",
+      "integrity": "sha512-SoRDqZoTLb7W0nk7B9OimRoUCGRUc6htEJrHcB0nbC1Fs6Uw5lxCGn/agYCbqgX3oiWs2MIu0UMt+1Ky634Enw==",
       "dependencies": {
         "@babel/runtime": "^7.15.4",
-        "cross-fetch": "^3.1.4",
+        "cross-fetch": "^3.1.5",
         "events": "^3.3.0"
       }
     },
@@ -71890,12 +71889,12 @@
       }
     },
     "trezor-connect": {
-      "version": "8.2.6",
-      "resolved": "https://registry.npmjs.org/trezor-connect/-/trezor-connect-8.2.6.tgz",
-      "integrity": "sha512-ioa/NkwtFHY94VI95q4JPdoDU3HaQFFIqdS47751zHa5q8qVBzwf5vgUrNS+q3vJ2ZNE7mTk/r4FjURtDB1xjA==",
+      "version": "8.2.7",
+      "resolved": "https://registry.npmjs.org/trezor-connect/-/trezor-connect-8.2.7.tgz",
+      "integrity": "sha512-SoRDqZoTLb7W0nk7B9OimRoUCGRUc6htEJrHcB0nbC1Fs6Uw5lxCGn/agYCbqgX3oiWs2MIu0UMt+1Ky634Enw==",
       "requires": {
         "@babel/runtime": "^7.15.4",
-        "cross-fetch": "^3.1.4",
+        "cross-fetch": "^3.1.5",
         "events": "^3.3.0"
       }
     },

--- a/package.json
+++ b/package.json
@@ -143,7 +143,7 @@
     "react-restore": "0.5.0",
     "react-transition-group": "4.4.2",
     "semver": "7.3.5",
-    "trezor-connect": "8.2.6",
+    "trezor-connect": "8.2.7",
     "uuid": "8.3.2",
     "web3-utils": "1.7.0",
     "ws": "8.5.0",


### PR DESCRIPTION
Trezor inexplicably included this commit in a patch version update which breaks the way we use Trezor Connect v8.2.6.

https://github.com/trezor/connect/commit/fb004cffa58a8297f5ad262d49583cfa77c86a62