### PR TITLE
Chains Panel updates

### DIFF
--- a/main/chains/index.js
+++ b/main/chains/index.js
@@ -272,7 +272,9 @@ class ChainConnection extends EventEmitter {
       const currentPresets = Object.assign({}, presets.default, presets[this.chainId])
       const target = primary.current === 'custom' ? primary.custom : currentPresets[primary.current]
 
-      if (!this.primary.provider || this.primary.currentPrimaryTarget !== target) {
+      console.log('target', target, this.primary.currentPrimaryTarget, target === this.primary.currentPrimaryTarget)
+
+      if (target && !this.primary.provider || this.primary.currentPrimaryTarget !== target) {
         log.info('Creating primary connection because it didn\'t exist or the target changed', { target })
         this.killProvider(this.primary.provider)
         this.primary.provider = null
@@ -292,13 +294,16 @@ class ChainConnection extends EventEmitter {
               this.primary.status = 'error'
               this.update('primary')
             } else {
+              console.log('getNetwork', err, response, this.primary.currentPrimaryTarget)
               this.primary.network = !err && response && !response.error ? response.result : ''
               if (this.primary.network && this.primary.network !== this.chainId) {
+                console.log('chain mismatch')
                 this.primary.connected = false
                 this.primary.type = ''
                 this.primary.status = 'chain mismatch'
                 this.update('primary')
               } else {
+                console.log('else')
                 this.primary.status = 'connected'
                 this.primary.connected = true
                 this.primary.type = ''


### PR DESCRIPTION
### Fixed:
Errors on selection of 'custom' in either primary or secondary dropdown for a given chain
Errors on entering a valid custom endpoint in either primary or secondary for a given chain

### Issues:
1. Deletion of a connected custom endpoint (primary) immediately reconnects - should error and load secondary.
2. Deletion of a connected custom endpoint (secondary) when primary disabled stalls at 'loading' - should error.
3. Occasional crashes when left for a while - might be related to the above issue(s).
4. Chain settings still not hooked up

Issue 1 log:
```
18:24:36.185 ›     Primary connection for network 1 connected
18:24:36.187 › Updating primary connection for chain 1 { status: 'connected', connected: false, type: '', network: '1' }
18:24:36.188 › Updating primary connection for chain 1 { status: 'connected', connected: true, type: '', network: '1' }
18:24:36.188 › Updating primary connection for chain 1 { status: 'connected', connected: true, type: '', network: '1' }
18:24:36.201 › ethereum:1's connection has been updated
18:24:36.201 › Secondary connection: ON
18:24:36.202 › Secondary connection on STANDBY false
18:24:36.202 › Updating secondary connection for chain 1 { status: 'standby', connected: false, type: '', network: '1' }
18:24:36.202 › Primary connection: ON
Closing WebSocket connection, reason:  (code 1006)
18:24:36.211 › ethereum:1's connection has been updated
18:24:36.212 › Secondary connection: ON
18:24:36.212 › Secondary connection on STANDBY true
18:24:36.212 › Primary connection: ON
```

Crash (after repro of issue 1) log:
```
18:56:50.431 › updating external data due to network update(s) { connectedChains: [ 1 ], newlyConnected: [ 1 ] }
18:56:50.432 › subscribing to rates updates for native currencies on chains: [ 1 ]
18:56:50.432 › subscribing to rates updates for tokens: []
18:56:50.432 › subscribing to chain updates for chains: [ 1 ]
[scanWorker] 18:59:56.176 no heartbeat received in 60 seconds, worker exiting
19:00:27.472 › balances worker disconnected
19:00:27.485 › balances worker exited with code null, signal: SIGHUP, pid: 17131
19:00:27.490 › balances controller stopped, restarting in 5 seconds
19:00:27.497 › stopping balances updates

<--- Last few GCs --->

[17113:0x7fbbc1ddd000]   468882 ms: Scavenge 3589.3 (4084.1) -> 3583.1 (4084.1) MB, 9.5 / 0.0 ms  (average mu = 0.084, current mu = 0.036) allocation failure; 
[17113:0x7fbbc1ddd000]   469138 ms: Scavenge 3589.8 (4084.3) -> 3585.8 (4086.1) MB, 16.4 / 0.0 ms  (average mu = 0.084, current mu = 0.036) allocation failure; 
[17113:0x7fbbc1ddd000]   469254 ms: Scavenge 3591.6 (4086.1) -> 3587.9 (4088.6) MB, 13.7 / 0.0 ms  (average mu = 0.084, current mu = 0.036) allocation failure; 


<--- JS stacktrace --->

[17113:0601/190314.218156:ERROR:node_bindings.cc(143)] Fatal error in V8: Ineffective mark-compacts near heap limit Allocation failed - JavaScript heap out of memory
/Users/sam/workspace/frame/node_modules/electron/dist/Electron.app/Contents/MacOS/Electron exited with signal SIGSEGV
```