### PR TITLE
Display 8/8 address chars during signing instead of 4/4

### DIFF
--- a/app/App/Panel/Main/Account/Requests/TransactionRequest/TxApproval/approvals/TokenSpend/index.js
+++ b/app/App/Panel/Main/Account/Requests/TransactionRequest/TxApproval/approvals/TokenSpend/index.js
@@ -9,6 +9,7 @@ import { ApprovalType } from '../../../../../../../../../../resources/constants'
 
 const numberRegex = /\.0+$|(\.[0-9]*[1-9])0+$/
 const MAX_HEX = '0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff'
+const DISPLAY_ADDRESS_HALF_DIGITS = 8; // TODO: consolidate to a global config
 
 const digitsLookup = [
   { value: 1, symbol: '' },
@@ -64,7 +65,7 @@ class TokenSpend extends React.Component {
       } else {
         amount = '0x' + custom.integerValue().toString(16)
       }
-      
+
       this.setState({ mode: 'custom', amount, customInput: value })
     }
   }
@@ -139,7 +140,7 @@ class TokenSpend extends React.Component {
             } : {}}
             onClick={() => {
               this.props.onApprove(
-                this.props.req, 
+                this.props.req,
                 ApprovalType.TokenSpendApproval,
                 { amount: this.state.amount }
               )
@@ -174,7 +175,7 @@ class TokenSpend extends React.Component {
                       {symbol}
                     </div>
                     {this.state.mode === 'custom' ? (
-                      <input 
+                      <input
                         autoFocus
                         type='text'
                         aria-label='Custom Amount'
@@ -190,7 +191,7 @@ class TokenSpend extends React.Component {
                       />
                     ) : (
                       <div>
-                        <div 
+                        <div
                           className='approveTokenSpendAmountNoInput'
                           role='textbox'
                           style={inputLock ? { cursor: 'default' } : null}
@@ -199,7 +200,7 @@ class TokenSpend extends React.Component {
                           }}
                         >
                           <div className='approveTokenSpendAmountNoInputNumber'>{displayAmount.number}</div>
-                          <div className='approveTokenSpendAmountNoInputSymbol'>{displayAmount.symbol}</div> 
+                          <div className='approveTokenSpendAmountNoInputSymbol'>{displayAmount.symbol}</div>
                         </div>
                       </div>
                     )}
@@ -214,7 +215,7 @@ class TokenSpend extends React.Component {
                     >
                       Requested
                     </div>
-                    <div 
+                    <div
                       className={this.state.mode === 'unlimited' ? 'approveTokenSpendPresetButton approveTokenSpendPresetButtonSelected' : 'approveTokenSpendPresetButton'}
                       role='button'
                       onClick={() => {
@@ -225,7 +226,7 @@ class TokenSpend extends React.Component {
                       <span className='approveTokenSpendPresetButtonInfinity'>{'Unlimited'}</span>
                     </div>
                     {!inputLock ? (
-                      <div 
+                      <div
                         className={this.state.mode === 'custom' ? 'approveTokenSpendPresetButton approveTokenSpendPresetButtonSelected' : 'approveTokenSpendPresetButton'}
                         role='button'
                         onClick={() => {
@@ -245,18 +246,18 @@ class TokenSpend extends React.Component {
                 {data.spender ? (
                   <div className='approveTokenSpendSpenderAddress'>
                     <div className='approveTokenSpendSpenderAddressLarge'>
-                      {data.spender.substring(0, 8)}
+                      {data.spender.substring(0, 2 + DISPLAY_ADDRESS_HALF_DIGITS)}
                       {svg.octicon('kebab-horizontal', { height: 15 })}
-                      {data.spender.substr(data.contract.length - 6)}
+                      {data.spender.substr(data.contract.length - DISPLAY_ADDRESS_HALF_DIGITS)}
                     </div>
-                    <div 
-                      className='approveTokenSpendSpenderAddressFull' 
+                    <div
+                      className='approveTokenSpendSpenderAddressFull'
                       onClick={() => {
                         link.send('tray:clipboardData', data.spender)
                         this.setState({ copyTokenRequester: true })
                         setTimeout(() => {
                           this.setState({ copyTokenRequester: false })
-                        }, 1000) 
+                        }, 1000)
                       }}
                     >
                       {this.state.copyTokenRequester ? 'ADDRESS COPIED' : data.spender}
@@ -270,14 +271,14 @@ class TokenSpend extends React.Component {
                   <div className='approveTokenSpendTokenSymbol'>
                     {symbol}
                   </div>
-                  <div 
+                  <div
                     className='approveTokenSpendTokenContract'
                     onClick={() => {
                       link.send('tray:clipboardData', data.contract)
                       this.setState({ copyTokenContract: true })
                       setTimeout(() => {
                         this.setState({ copyTokenContract: false })
-                      }, 1000) 
+                      }, 1000)
                     }}
                   >
                     {this.state.copyTokenContract ? 'ADDRESS COPIED' : data.contract}

--- a/app/App/Panel/Main/Account/Requests/TransactionRequest/TxApproval/approvals/TokenSpend/index.js
+++ b/app/App/Panel/Main/Account/Requests/TransactionRequest/TxApproval/approvals/TokenSpend/index.js
@@ -5,11 +5,10 @@ import BigNumber from 'bignumber.js'
 import svg from '../../../../../../../../../../resources/svg'
 import link from '../../../../../../../../../../resources/link'
 
-import { ApprovalType } from '../../../../../../../../../../resources/constants'
+import { ADDRESS_DISPLAY_CHARS, ApprovalType } from '../../../../../../../../../../resources/constants'
 
 const numberRegex = /\.0+$|(\.[0-9]*[1-9])0+$/
 const MAX_HEX = '0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff'
-const DISPLAY_ADDRESS_HALF_DIGITS = 8; // TODO: consolidate to a global config
 
 const digitsLookup = [
   { value: 1, symbol: '' },
@@ -246,9 +245,12 @@ class TokenSpend extends React.Component {
                 {data.spender ? (
                   <div className='approveTokenSpendSpenderAddress'>
                     <div className='approveTokenSpendSpenderAddressLarge'>
-                      {data.spender.substring(0, 2 + DISPLAY_ADDRESS_HALF_DIGITS)}
+                      {
+                        // 0x prefix plus leading characters of address
+                        data.spender.substring(0, 2 + ADDRESS_DISPLAY_CHARS)
+                      }
                       {svg.octicon('kebab-horizontal', { height: 15 })}
-                      {data.spender.substr(data.contract.length - DISPLAY_ADDRESS_HALF_DIGITS)}
+                      {data.spender.substr(data.contract.length - ADDRESS_DISPLAY_CHARS)}
                     </div>
                     <div
                       className='approveTokenSpendSpenderAddressFull'

--- a/app/App/Panel/Main/Account/Requests/TransactionRequest/TxApproval/approvals/TokenSpend/index.js
+++ b/app/App/Panel/Main/Account/Requests/TransactionRequest/TxApproval/approvals/TokenSpend/index.js
@@ -245,9 +245,9 @@ class TokenSpend extends React.Component {
                 {data.spender ? (
                   <div className='approveTokenSpendSpenderAddress'>
                     <div className='approveTokenSpendSpenderAddressLarge'>
-                      {data.spender.substring(0, 6)}
+                      {data.spender.substring(0, 8)}
                       {svg.octicon('kebab-horizontal', { height: 15 })}
-                      {data.spender.substr(data.contract.length - 4)}
+                      {data.spender.substr(data.contract.length - 6)}
                     </div>
                     <div 
                       className='approveTokenSpendSpenderAddressFull' 

--- a/app/App/Panel/Main/Account/Requests/TransactionRequest/TxRecipient/index.js
+++ b/app/App/Panel/Main/Account/Requests/TransactionRequest/TxRecipient/index.js
@@ -38,7 +38,7 @@ class TxRecipient extends React.Component {
             <div className='_txRecipientSlice _txRecipientValue'>
               {ensName
                 ? <span>{ensName}</span>
-                : <span>{address.substring(0, 6)}{svg.octicon('kebab-horizontal', { height: 15 })}{address.substring(address.length - 4)}</span>
+                : <span>{address.substring(0, 8)}{svg.octicon('kebab-horizontal', { height: 15 })}{address.substring(address.length - 6)}</span>
               }
               {req.decodedData && req.decodedData.contractName ? ( 
                 <span className={'_txRecipientContract'}>{(() => {

--- a/app/App/Panel/Main/Account/Requests/TransactionRequest/TxRecipient/index.js
+++ b/app/App/Panel/Main/Account/Requests/TransactionRequest/TxRecipient/index.js
@@ -4,6 +4,8 @@ import Restore from 'react-restore'
 import link from '../../../../../../../../resources/link'
 import svg from '../../../../../../../../resources/svg'
 
+const DISPLAY_ADDRESS_HALF_DIGITS = 8; // TODO: consolidate to a global config
+
 class TxRecipient extends React.Component {
   constructor (...args) {
     super(...args)
@@ -38,9 +40,9 @@ class TxRecipient extends React.Component {
             <div className='_txRecipientSlice _txRecipientValue'>
               {ensName
                 ? <span>{ensName}</span>
-                : <span>{address.substring(0, 8)}{svg.octicon('kebab-horizontal', { height: 15 })}{address.substring(address.length - 6)}</span>
+                : <span>{address.substring(0, 2 + DISPLAY_ADDRESS_HALF_DIGITS)}{svg.octicon('kebab-horizontal', { height: 15 })}{address.substring(address.length - DISPLAY_ADDRESS_HALF_DIGITS)}</span>
               }
-              {req.decodedData && req.decodedData.contractName ? ( 
+              {req.decodedData && req.decodedData.contractName ? (
                 <span className={'_txRecipientContract'}>{(() => {
                   if (req.decodedData.contractName.length > 11) return `${req.decodedData.contractName.substr(0, 9)}..`
                   return req.decodedData.contractName

--- a/app/App/Panel/Main/Account/Requests/TransactionRequest/TxRecipient/index.js
+++ b/app/App/Panel/Main/Account/Requests/TransactionRequest/TxRecipient/index.js
@@ -1,10 +1,9 @@
 import React from 'react'
 import Restore from 'react-restore'
+import { ADDRESS_DISPLAY_CHARS } from '../../../../../../../../resources/constants'
 
 import link from '../../../../../../../../resources/link'
 import svg from '../../../../../../../../resources/svg'
-
-const DISPLAY_ADDRESS_HALF_DIGITS = 8; // TODO: consolidate to a global config
 
 class TxRecipient extends React.Component {
   constructor (...args) {
@@ -40,7 +39,7 @@ class TxRecipient extends React.Component {
             <div className='_txRecipientSlice _txRecipientValue'>
               {ensName
                 ? <span>{ensName}</span>
-                : <span>{address.substring(0, 2 + DISPLAY_ADDRESS_HALF_DIGITS)}{svg.octicon('kebab-horizontal', { height: 15 })}{address.substring(address.length - DISPLAY_ADDRESS_HALF_DIGITS)}</span>
+                : <span>{address.substring(0, 2 + ADDRESS_DISPLAY_CHARS)}{svg.octicon('kebab-horizontal', { height: 15 })}{address.substring(address.length - ADDRESS_DISPLAY_CHARS)}</span>
               }
               {req.decodedData && req.decodedData.contractName ? (
                 <span className={'_txRecipientContract'}>{(() => {

--- a/app/App/Panel/Main/Account/Requests/TransactionRequest/index.js
+++ b/app/App/Panel/Main/Account/Requests/TransactionRequest/index.js
@@ -432,7 +432,7 @@ class TransactionRequest extends React.Component {
                           <span className='monitorSub'>{'TO'} </span>
                           <span className='monitorValue'>
                             <span className='monitorValue0x'>{'0x'}</span>
-                            {toAddress.substring(2, 7)}
+                            {toAddress.substring(2, 5)}
                             {svg.octicon('kebab-horizontal', { height: 14 })}
                             {toAddress.substring(toAddress.length - 3)}
                            </span>

--- a/app/App/Panel/Main/Account/Requests/TransactionRequest/index.js
+++ b/app/App/Panel/Main/Account/Requests/TransactionRequest/index.js
@@ -432,7 +432,7 @@ class TransactionRequest extends React.Component {
                           <span className='monitorSub'>{'TO'} </span>
                           <span className='monitorValue'>
                             <span className='monitorValue0x'>{'0x'}</span>
-                            {toAddress.substring(2, 5)}
+                            {toAddress.substring(2, 7)}
                             {svg.octicon('kebab-horizontal', { height: 14 })}
                             {toAddress.substring(toAddress.length - 3)}
                            </span>

--- a/resources/constants/index.ts
+++ b/resources/constants/index.ts
@@ -3,3 +3,8 @@ export enum ApprovalType {
   GasLimitApproval = 'approveGasLimit',
   TokenSpendApproval = 'approveTokenSpend'
 }
+
+const ADDRESS_DISPLAY_CHARS = 8
+export {
+  ADDRESS_DISPLAY_CHARS
+}


### PR DESCRIPTION
# Overview
Patch UI to display 8 leading and 8 trailing characters for transaction request instead of 4 and 4.

# Motivation
This fixes security issues around address collisions which match first/last 4 characters. 8 digits is not enough and can be bruteforced locally.

For the forseeable future, 16 characters of collision protection should be reasonable. Extrapolating from 2019 data provided by (@)banteg:
![image](https://user-images.githubusercontent.com/3518037/176480799-d9e35895-552b-45b7-8fea-b85f6f39fa8d.png)

# New Look
![image](https://user-images.githubusercontent.com/3518037/176480147-7f446fdf-fe7a-479e-b2fc-58c95c616a14.png)

# Old Look
![image](https://user-images.githubusercontent.com/3518037/176141807-1531e730-45ec-42db-a8a9-41990cfe3a8c.png)

# Security Incident
![image](https://user-images.githubusercontent.com/3518037/176142065-00df3713-e90a-4ed7-9501-da93c7986c72.png)

https://twitter.com/Alexintosh/status/1540047636467748870

# Author
Patched written by cory.eth (Cory Gabrielsen) (@cory_eth).