### PR TITLE
[LATTICE] fixes 'undefined (reading 'encode')'

### DIFF
--- a/main/signers/lattice/Lattice/index.ts
+++ b/main/signers/lattice/Lattice/index.ts
@@ -1,5 +1,5 @@
 import { Client, Utils, Constants } from 'gridplus-sdk'
-import rlp from 'rlp'
+import { encode } from 'rlp'
 import { padToEven, addHexPrefix } from 'ethereumjs-util'
 import { hexToNumber } from 'web3-utils'
 import log from 'electron-log'
@@ -366,7 +366,7 @@ export default class Lattice extends Signer {
     if (fwVersion && (fwVersion.major > 0 || fwVersion.minor >= 15)) {
       const payload = tx.type ?
         tx.getMessageToSign(false) :
-        rlp.encode(tx.getMessageToSign(false))
+        encode(tx.getMessageToSign(false))
 
       const to = tx.to?.toString() ?? undefined
 


### PR DESCRIPTION
### What does this do?
This fixes the error when using a Lattice1 to sign messages which aren't EIP-1559 typed transactions. 

Specifically, the error:
"TYPEERROR: CANNOT READ PROPERTIES OF UNDEFINED (READING 'ENCODE')"

<img width="179" alt="Screen Shot 2022-06-28 at 3 17 38 PM" src="https://user-images.githubusercontent.com/276137/176268617-16805c02-c891-4903-bb03-cf37749895fb.png">


### How does it work?

The issue relates to the mismatched versions of "rlp" which frame pulls in, versus the one that "gridplus-sdk" is expected. 

### Ways to test

Prior this change, attempting to send and sign a `tx` on Ganache v7.3.2 using a Lattice1 caused the above error. Afterwards, the `tx` encoded and sent to the Lattice1 for signing.

### Known Issues

There is probably a more "correct" way to solve this problem, and it's possible that it's no longer be necessary for integrations (like Frame) to need to handle transaction types in newer version of the SDK. However, we didn't want to create a larger diff than was necessary. We're open to other ideas, as well.