### PR TITLE
Rename xDAI to Gnosis and update the RPC endpoint

### DIFF
--- a/main/store/state/index.js
+++ b/main/store/state/index.js
@@ -271,7 +271,7 @@ const initial = {
           idchain: 'wss://idchain.one/ws/'
         },
         100: {
-          poa: 'https://dai.poa.network'
+          poa: 'https://rpc.gnosischain.com/'
         },
         137: {
           infura: 'https://polygon-mainnet.infura.io/v3/786ade30f36244469480aa5c2bf0743b'
@@ -419,8 +419,8 @@ const initial = {
           type: 'ethereum',
           layer: 'sidechain',
           symbol: 'xDAI',
-          name: 'xDai',
-          explorer: 'https://blockscout.com/poa/xdai',
+          name: 'Gnosis',
+          explorer: 'https://blockscout.com/xdai/mainnet',
           gas: {
             price: {
               selected: 'standard',


### PR DESCRIPTION
Renames xDAI to Gnosis chain and updates the RPC endpoint as the old one was broken.