### PR TITLE
Change Arbitrum explorer to arbiscan.io

### DIFF
--- a/main/store/state/index.js
+++ b/main/store/state/index.js
@@ -458,7 +458,7 @@ const initial = {
           layer: 'rollup',
           symbol: 'ETH',
           name: 'Arbitrum',
-          explorer: 'https://explorer.arbitrum.io',
+          explorer: 'https://arbiscan.io',
           gas: {
             price: {
               selected: 'standard',


### PR DESCRIPTION
There is an Etherscan-like explorer for Arbitrum at [arbiscan.io](https://arbiscan.io) with a more complete feature set.
https://developer.offchainlabs.com/docs/public_chains