### PR TITLE
fix isVisible tray toggle before init error

### DIFF
--- a/main/windows/index.ts
+++ b/main/windows/index.ts
@@ -254,7 +254,8 @@ class Tray {
   }
 
   toggle () {
-    if (this.recentAutohide) return
+    if (!this.isReady() || this.recentAutohide) return
+
     const showing = (windows.tray as BrowserWindow).isVisible()
     showing ? this.hide() : this.show()
   }


### PR DESCRIPTION
This "cannot read property isVisible" error seems to be a result of the tray toggle function being called before the window object has fully initialised. We can avoid it by returning out of the toggle function in the cases where the window is not ready.