### PR TITLE
Typed data param order fix

### DIFF
--- a/main/provider/index.ts
+++ b/main/provider/index.ts
@@ -785,7 +785,7 @@ export class Provider extends EventEmitter {
 
     if (['eth_signTypedData', 'eth_signTypedData_v1', 'eth_signTypedData_v3', 'eth_signTypedData_v4'].includes(method)) {
       const underscoreIndex = method.lastIndexOf('_')
-      const version = (underscoreIndex > 3 ? method.substring(underscoreIndex + 1) : 'v1').toUpperCase() as Version
+      const version = (underscoreIndex > 3 ? method.substring(underscoreIndex + 1) : 'v4').toUpperCase() as Version
       return this.signTypedData(payload, version, res)
     }
     

--- a/main/provider/index.ts
+++ b/main/provider/index.ts
@@ -785,7 +785,7 @@ export class Provider extends EventEmitter {
 
     if (['eth_signTypedData', 'eth_signTypedData_v1', 'eth_signTypedData_v3', 'eth_signTypedData_v4'].includes(method)) {
       const underscoreIndex = method.lastIndexOf('_')
-      const version = (underscoreIndex > 3 ? method.substring(underscoreIndex + 1) : 'v4').toUpperCase() as Version
+      const version = (underscoreIndex > 3 ? method.substring(underscoreIndex + 1) : 'v1').toUpperCase() as Version
       return this.signTypedData(payload, version, res)
     }
     

--- a/main/provider/index.ts
+++ b/main/provider/index.ts
@@ -530,8 +530,8 @@ export class Provider extends EventEmitter {
   }
 
   signTypedData (rawPayload: RPCRequestPayload, version: Version, res: RPCRequestCallback) {
-    // v1 has the param order as: [data, address, ...], all other versions have [address, data, ...]
-    const orderedParams = version === 'V1'
+    // ensure param order is [address, data, ...] regardless of version
+    const orderedParams = utils.isAddress(rawPayload.params[1]) && !utils.isAddress(rawPayload.params[0])
       ? [rawPayload.params[1], rawPayload.params[0], ...rawPayload.params.slice(2)]
       : [...rawPayload.params]
 

--- a/test/main/provider/index.test.js
+++ b/test/main/provider/index.test.js
@@ -982,7 +982,7 @@ describe('#send', () => {
 
       send({ method: 'eth_signTypedData', params })
 
-      verifyRequest('V1')
+      verifyRequest('V4')
     })
 
     it('does not submit a request from an unknown account', done => {

--- a/test/main/provider/index.test.js
+++ b/test/main/provider/index.test.js
@@ -951,11 +951,14 @@ describe('#send', () => {
     }
 
     const validRequests = [
-      // the first 2 parameters are reversed for V1
-      { method: 'eth_signTypedData', params: [typedData, address], version: 'V1' },
-      { method: 'eth_signTypedData_v1', params: [typedData, address], version: 'V1' },
+      { method: 'eth_signTypedData', params: [address, typedData], version: 'V4' },
+      { method: 'eth_signTypedData_v1', params: [address, typedData], version: 'V1' },
       { method: 'eth_signTypedData_v3', params: [address, typedData], version: 'V3' },
-      { method: 'eth_signTypedData_v4', params: [address, typedData], version: 'V4' }
+      { method: 'eth_signTypedData_v4', params: [address, typedData], version: 'V4' },
+      { method: 'eth_signTypedData', params: [typedData, address], version: 'V4', dataFirst: true },
+      { method: 'eth_signTypedData_v1', params: [typedData, address], version: 'V1', dataFirst: true },
+      { method: 'eth_signTypedData_v3', params: [typedData, address], version: 'V3', dataFirst: true },
+      { method: 'eth_signTypedData_v4', params: [typedData, address], version: 'V4', dataFirst: true }
     ]
 
     function verifyRequest (version) {
@@ -966,8 +969,8 @@ describe('#send', () => {
       expect(accountRequests[0].version).toBe(version)
     }
     
-    validRequests.forEach(({ method, params, version }) => {
-      it(`submits a ${method} request to sign typed data`, () => {
+    validRequests.forEach(({ method, params, version, dataFirst }) => {
+      it(`submits a ${method} request to sign typed data${dataFirst ? ' with data sent as the first param' : ''}`, () => {
         send({ method, params })
   
         verifyRequest(version)

--- a/test/main/provider/index.test.js
+++ b/test/main/provider/index.test.js
@@ -951,11 +951,11 @@ describe('#send', () => {
     }
 
     const validRequests = [
-      { method: 'eth_signTypedData', params: [address, typedData], version: 'V4' },
+      { method: 'eth_signTypedData', params: [address, typedData], version: 'V1' },
       { method: 'eth_signTypedData_v1', params: [address, typedData], version: 'V1' },
       { method: 'eth_signTypedData_v3', params: [address, typedData], version: 'V3' },
       { method: 'eth_signTypedData_v4', params: [address, typedData], version: 'V4' },
-      { method: 'eth_signTypedData', params: [typedData, address], version: 'V4', dataFirst: true },
+      { method: 'eth_signTypedData', params: [typedData, address], version: 'V1', dataFirst: true },
       { method: 'eth_signTypedData_v1', params: [typedData, address], version: 'V1', dataFirst: true },
       { method: 'eth_signTypedData_v3', params: [typedData, address], version: 'V3', dataFirst: true },
       { method: 'eth_signTypedData_v4', params: [typedData, address], version: 'V4', dataFirst: true }
@@ -982,7 +982,7 @@ describe('#send', () => {
 
       send({ method: 'eth_signTypedData', params })
 
-      verifyRequest('V4')
+      verifyRequest('V1')
     })
 
     it('does not submit a request from an unknown account', done => {


### PR DESCRIPTION
Ensuring typed data param order does not break the signing flow