### PR TITLE
respond to add chain request before editing chain

### DIFF
--- a/app/App/Main/Account/Requests/ChainRequest/index.js
+++ b/app/App/Main/Account/Requests/ChainRequest/index.js
@@ -13,10 +13,7 @@ class ChainRequest extends React.Component {
   }
 
   render () {
-    const status = this.props.req.status
-    const notice = this.props.req.notice
-    const type = this.props.req.type
-    const chain = this.props.req.chain
+    const { status, notice, type, chain } = this.props.req
     
     let requestClass = 'signerRequest'
     if (status === 'success') requestClass += ' signerRequestSuccess'
@@ -83,14 +80,20 @@ class ChainRequest extends React.Component {
             <div 
               className='requestDecline' 
               style={{ pointerEvents: this.state.allowInput ? 'auto' : 'none'}}
-              onClick={() => { if (this.state.allowInput) link.send('tray:resolveRequest', this.props.req)
+              onClick={() => { if (this.state.allowInput) {
+                const err = { code: 4001, message: 'User rejected the request' }
+                link.send('tray:rejectRequest', this.props.req, err)
+              }
             }}>
               <div className='requestDeclineButton _txButton _txButtonBad'>Decline</div>
             </div>
             <div 
               className='requestSign' 
               style={{ pointerEvents: this.state.allowInput ? 'auto' : 'none'}}
-              onClick={() => { if (this.state.allowInput) this.store.notify('addChain', this.props.req) 
+              onClick={() => { if (this.state.allowInput) {
+                link.send('tray:resolveRequest', this.props.req, null)
+                link.send('tray:action', 'navDash', { view: 'notify', data: { notify: 'addChain', notifyData: { chain } } })
+              }
             }}>
               <div className='requestSignButton _txButton'>Review</div>
             </div>

--- a/app/App/Main/Account/Requests/ChainRequest/index.js
+++ b/app/App/Main/Account/Requests/ChainRequest/index.js
@@ -80,21 +80,24 @@ class ChainRequest extends React.Component {
             <div 
               className='requestDecline' 
               style={{ pointerEvents: this.state.allowInput ? 'auto' : 'none'}}
-              onClick={() => { if (this.state.allowInput) {
-                const err = { code: 4001, message: 'User rejected the request' }
-                link.send('tray:rejectRequest', this.props.req, err)
+              onClick={() => { 
+                if (this.state.allowInput) {
+                  link.send('tray:rejectRequest', this.props.req)
+                }
               }
-            }}>
+            }>
               <div className='requestDeclineButton _txButton _txButtonBad'>Decline</div>
             </div>
             <div 
               className='requestSign' 
               style={{ pointerEvents: this.state.allowInput ? 'auto' : 'none'}}
-              onClick={() => { if (this.state.allowInput) {
-                link.send('tray:resolveRequest', this.props.req, null)
-                link.send('tray:action', 'navDash', { view: 'notify', data: { notify: 'addChain', notifyData: { chain } } })
+              onClick={() => {
+                if (this.state.allowInput) {
+                  link.send('tray:resolveRequest', this.props.req, null)
+                  link.send('tray:action', 'navDash', { view: 'notify', data: { notify: 'addChain', notifyData: { chain } } })
+                }
               }
-            }}>
+            }>
               <div className='requestSignButton _txButton'>Review</div>
             </div>
           </div>

--- a/dash/App/Notify/AddChain/index.js
+++ b/dash/App/Notify/AddChain/index.js
@@ -64,10 +64,6 @@ class AddChain extends React.Component {
     }
 
     link.send('tray:addChain', chainToAdd)
-
-    if (this.props.req) {
-      link.send('tray:resolveRequest', this.props.req)
-    }
   }
 
   validateSubmit (enteredChain) {

--- a/main/accounts/Account/index.ts
+++ b/main/accounts/Account/index.ts
@@ -193,13 +193,30 @@ class FrameAccount {
     if (knownRequest) {
       if (knownRequest.res) {
         const { id, jsonrpc } = req.payload || {}
-        
         knownRequest.res({ id, jsonrpc, result })
       }
-      store.navClearReq(req.handlerId)
-      delete this.requests[req.handlerId]
-      this.update()
+
+      this.clearRequest(knownRequest)
     }
+  }
+
+  rejectRequest (req: AccountRequest, error: EVMError) {
+    const knownRequest = this.requests[req.handlerId]
+
+    if (knownRequest) {
+      if (knownRequest.res) {
+        const { id, jsonrpc } = req.payload || {}
+        knownRequest.res({ id, jsonrpc, error })
+      }
+
+      this.clearRequest(knownRequest)
+    }
+  }
+
+  private clearRequest (req: AccountRequest) {
+    store.navClearReq(req.handlerId)
+    delete this.requests[req.handlerId]
+    this.update()
   }
 
   addRequiredApproval (req: TransactionRequest, type: ApprovalType, data: any = {}, onApprove: (data: any) => void = () => {}) {

--- a/main/accounts/Account/index.ts
+++ b/main/accounts/Account/index.ts
@@ -187,12 +187,11 @@ class FrameAccount {
     return this.requests[id] as T
   }
 
-  resolveRequest <T> (req: AccountRequest, result?: T) {
-    const knownRequest = this.requests[req.handlerId]
+  resolveRequest <T> ({ handlerId, payload: { id, jsonrpc } }: AccountRequest, result?: T) {
+    const knownRequest = this.requests[handlerId]
 
     if (knownRequest) {
       if (knownRequest.res) {
-        const { id, jsonrpc } = req.payload || {}
         knownRequest.res({ id, jsonrpc, result })
       }
 
@@ -200,12 +199,11 @@ class FrameAccount {
     }
   }
 
-  rejectRequest (req: AccountRequest, error: EVMError) {
-    const knownRequest = this.requests[req.handlerId]
+  rejectRequest ({ handlerId, payload: { id, jsonrpc } }: AccountRequest, error: EVMError) {
+    const knownRequest = this.requests[handlerId]
 
     if (knownRequest) {
       if (knownRequest.res) {
-        const { id, jsonrpc } = req.payload || {}
         knownRequest.res({ id, jsonrpc, error })
       }
 
@@ -213,9 +211,9 @@ class FrameAccount {
     }
   }
 
-  private clearRequest (req: AccountRequest) {
-    store.navClearReq(req.handlerId)
-    delete this.requests[req.handlerId]
+  private clearRequest ({ handlerId }: AccountRequest) {
+    store.navClearReq(handlerId)
+    delete this.requests[handlerId]
     this.update()
   }
 

--- a/main/accounts/Account/index.ts
+++ b/main/accounts/Account/index.ts
@@ -187,7 +187,7 @@ class FrameAccount {
     return this.requests[id] as T
   }
 
-  resolveRequest <T> ({ handlerId, payload: { id, jsonrpc } }: AccountRequest, result?: T) {
+  resolveRequest ({ handlerId, payload: { id, jsonrpc } }: AccountRequest, result?: any) {
     const knownRequest = this.requests[handlerId]
 
     if (knownRequest) {

--- a/main/accounts/index.ts
+++ b/main/accounts/index.ts
@@ -531,10 +531,17 @@ export class Accounts extends EventEmitter {
     }
   }
 
-  resolveRequest (req: AccountRequest) {
+  resolveRequest <T> (req: AccountRequest, result?: T) {
     const currentAccount = this.current()
     if (currentAccount && currentAccount.resolveRequest) {
-      currentAccount.resolveRequest(req)
+      currentAccount.resolveRequest(req, result)
+    }
+  }
+
+  rejectRequest (req: AccountRequest, error: EVMError) {
+    const currentAccount = this.current()
+    if (currentAccount) {
+      currentAccount.rejectRequest(req, error)
     }
   }
 

--- a/main/index.ts
+++ b/main/index.ts
@@ -165,8 +165,12 @@ ipcMain.on('dash:reloadSigner', (e, id) => {
   signers.reload(id)
 })
 
-ipcMain.on('tray:resolveRequest', (e, req) => {
-  accounts.resolveRequest(req)
+ipcMain.on('tray:resolveRequest', (e, req, result) => {
+  accounts.resolveRequest(req, result)
+})
+
+ipcMain.on('tray:rejectRequest', (e, req, err) => {
+  accounts.rejectRequest(req, err)
 })
 
 ipcMain.on('tray:openExternal', (e, url) => {

--- a/main/index.ts
+++ b/main/index.ts
@@ -169,7 +169,8 @@ ipcMain.on('tray:resolveRequest', (e, req, result) => {
   accounts.resolveRequest(req, result)
 })
 
-ipcMain.on('tray:rejectRequest', (e, req, err) => {
+ipcMain.on('tray:rejectRequest', (e, req) => {
+  const err = { code: 4001, message: 'User rejected the request' }
   accounts.rejectRequest(req, err)
 })
 

--- a/main/provider/index.ts
+++ b/main/provider/index.ts
@@ -613,7 +613,7 @@ export class Provider extends EventEmitter {
         store.switchOriginChain(originId, chainId, origin.chain.type)
       }
 
-      return res({ id: payload.id, jsonrpc: '2.0', result: undefined })
+      return res({ id: payload.id, jsonrpc: '2.0', result: null })
     } catch (e) {
       return resError(e as EVMError, payload, res)
     }
@@ -628,8 +628,7 @@ export class Provider extends EventEmitter {
       chainName, 
       nativeCurrency, 
       rpcUrls = [], 
-      blockExplorerUrls = [],
-      iconUrls = [] 
+      blockExplorerUrls = []
     } = payload.params[0]
 
     if (!chainId) return resError('addChain request missing chainId', payload, res)
@@ -658,8 +657,7 @@ export class Provider extends EventEmitter {
           symbol: nativeCurrency.symbol,
           primaryRpc: rpcUrls[0],
           secondaryRpc: rpcUrls[1],
-          explorer: blockExplorerUrls[0], 
-          iconUrls
+          explorer: blockExplorerUrls[0]
         },
         account: (accounts.getAccounts() || [])[0],
         origin: payload._origin,

--- a/main/provider/index.ts
+++ b/main/provider/index.ts
@@ -619,7 +619,7 @@ export class Provider extends EventEmitter {
     }
   }
 
-  addEthereumChain (payload: RPCRequestPayload, res: RPCRequestCallback) {
+  private addEthereumChain (payload: RPCRequestPayload, res: RPCRequestCallback) {
     if (!payload.params[0]) return resError('addChain request missing params', payload, res)
 
     const type = 'ethereum'

--- a/main/provider/index.ts
+++ b/main/provider/index.ts
@@ -638,8 +638,8 @@ export class Provider extends EventEmitter {
     const handlerId = this.addRequestHandler(res)
 
     // Check if chain exists
-    const id = parseInt(chainId)
-    if (!Number.isInteger(id)) throw new Error('Invalid chain id')
+    const id = parseInt(chainId, 16)
+    if (!Number.isInteger(id)) return resError('Invalid chain id', payload, res)
 
     const exists = Boolean(store('main.networks', type, id))
     if (exists) {
@@ -652,7 +652,7 @@ export class Provider extends EventEmitter {
         type: 'addChain',
         chain: {
           type,
-          id: chainId,
+          id,
           name: chainName,
           symbol: nativeCurrency.symbol,
           primaryRpc: rpcUrls[0],

--- a/test/app/App/Notify/AddChain/index.test.js
+++ b/test/app/App/Notify/AddChain/index.test.js
@@ -23,49 +23,49 @@ afterAll(() => {
 
 describe('rendering', () => {
   it('renders the first provided RPC as the primary RPC', () => {
-    const { getByLabelText } = renderForm({ chain: { primaryRpc: 'https://myrpc.polygon.net' } })
+    const { getByLabelText } = setupComponent(<AddChain chain={{ primaryRpc: 'https://myrpc.polygon.net' }} />)
 
     const primaryRpcInput = getByLabelText('Primary RPC')
     expect(primaryRpcInput.value).toEqual('https://myrpc.polygon.net')
   })
 
   it('renders the default primary RPC text', () => {
-    const { getByLabelText } = renderForm()
+    const { getByLabelText } = setupComponent(<AddChain chain={{}} />)
 
     const primaryRpcInput = getByLabelText('Primary RPC')
     expect(primaryRpcInput.value).toEqual('Primary Endpoint')
   })
 
   it('renders the second provided RPC as the secondary RPC', () => {
-    const { getByLabelText } = renderForm({ chain: { secondaryRpc: 'https://my-backup-rpc.polygon.net' } })
+    const { getByLabelText } = setupComponent(<AddChain chain={{ secondaryRpc: 'https://my-backup-rpc.polygon.net'}} />)
 
     const secondaryRpcInput = getByLabelText('Secondary RPC')
     expect(secondaryRpcInput.value).toEqual('https://my-backup-rpc.polygon.net')
   })
 
   it('renders the default secondary RPC text', () => {
-    const { getByLabelText } = renderForm()
+    const { getByLabelText } = setupComponent(<AddChain chain={{}} />)
 
     const secondaryRpcInput = getByLabelText('Secondary RPC')
     expect(secondaryRpcInput.value).toEqual('Secondary Endpoint')
   })
 
   it('renders the title', () => {
-    const { getByRole } = renderForm()
+    const { getByRole } = setupComponent(<AddChain chain={{}} />)
   
     const titleSection = getByRole('title')
     expect(titleSection.textContent).toBe('Add New Chain')
   })
   
   it('renders the submit button text', () => {
-    const { getByRole } = renderForm({ chain: { id: 137, name: 'Polygon' }})
+    const { getByRole } = setupComponent(<AddChain chain={{ id: 137, name: 'Polygon' }} />)
   
     const submitButton = getByRole('button')
     expect(submitButton.textContent).toBe('Add Chain')
   })
   
   it('renders the correct text after the form is submitted', async () => {
-    const { user, getByRole } = renderForm({ chain: { id: 137, name: 'Polygon' }})
+    const { user, getByRole } = setupComponent(<AddChain chain={{ id: 137, name: 'Polygon' }} />)
   
     await user.click(getByRole('button'))
   
@@ -74,7 +74,7 @@ describe('rendering', () => {
   })
   
   it('renders a warning if the entered chain id already exists', () => {
-    const { getByRole } = renderForm({ chain: { id: 1, name: 'Mainnet' }})
+    const { getByRole } = setupComponent(<AddChain chain={{ id: 1, name: 'Mainnet' }} />)
   
     const submitButton = getByRole('button')
     expect(submitButton.textContent).toMatch(/chain id already exists/i)
@@ -95,7 +95,7 @@ describe('submitting', () => {
       }
     })
 
-    const { user, getByRole } = renderForm({ chain: { id: 1, name: 'Mainnet' }})
+    const { user, getByRole } = setupComponent(<AddChain chain={{ id: 1, name: 'Mainnet' }} />)
     
     await user.click(getByRole('button'))
     
@@ -103,18 +103,19 @@ describe('submitting', () => {
   })
   
   it('adds a valid chain', async () => {
-    const { user, getByRole } = renderForm({
-    chain: {
-      id: 42162,
-      type: 'ethereum',
-      name: 'Arbitrum Rinkeby',
-      symbol: 'ETH',
-      explorer: 'https://rinkeby.arbiscan.io',
-      primaryRpc: 'https://arbitrum-rinkeby.infura.com',
-      secondaryRpc: 'https://myrpc.arbrink.net',
-      layer: 'sidechain'
-    }
-    })
+    const { user, getByRole } = setupComponent(
+      <AddChain
+        chain={{
+          id: 42162,
+          type: 'ethereum',
+          name: 'Arbitrum Rinkeby',
+          symbol: 'ETH',
+          explorer: 'https://rinkeby.arbiscan.io',
+          primaryRpc: 'https://arbitrum-rinkeby.infura.com',
+          secondaryRpc: 'https://myrpc.arbrink.net',
+          layer: 'sidechain'
+        }}
+    />)
     
     await user.click(getByRole('button'))
     
@@ -134,14 +135,15 @@ describe('submitting', () => {
   })
   
   it('allows the user to change RPCs before submitting', async () => {
-    const { user, getByRole, getByLabelText } = renderForm({
-      chain: {
-        id: 42162,
-        name: 'Arbitrum Rinkeby',
-        primaryRpc: 'https://arbitrum-rinkeby.infura.com',
-        secondaryRpc: 'https://myrpc.arbrink.net'
-      }
-    })
+    const { user, getByRole, getByLabelText } = setupComponent(
+      <AddChain 
+        chain={{
+          id: 42162,
+          name: 'Arbitrum Rinkeby',
+          primaryRpc: 'https://arbitrum-rinkeby.infura.com',
+          secondaryRpc: 'https://myrpc.arbrink.net'
+        }}
+      />)
     
     const primaryRpcInput = getByLabelText('Primary RPC')
     await user.clear(primaryRpcInput)
@@ -161,38 +163,4 @@ describe('submitting', () => {
       })
     )
   })
-  
-  it('resolves an add chain request after submission', async () => {
-    const req = { handlerId: '1234' }
-    const { user, getByRole } = renderForm({
-      req,
-      chain: {
-        id: 137,
-        name: 'Polygon'
-      }
-    })
-    
-    await user.click(getByRole('button'))
-    
-    expect(link.send).toHaveBeenNthCalledWith(2, 'tray:resolveRequest', req)
-  })
-  
-  it('does not attempt to resolve an undefined request', async () => {
-    const { user, getByRole } = renderForm({
-      chain: {
-        id: 137,
-        name: 'Polygon'
-      }
-    })
-    
-    await user.click(getByRole('button'))
-    
-    expect(link.send).toHaveBeenCalledTimes(1)
-    expect(link.send.mock.calls[0][0]).not.toBe('tray:resolveRequest')
-  })
 })
-
-// helper functions
-function renderForm ({ req, chain = {} } = {}) {
-  return setupComponent(<AddChain {...{req, chain} }/>)
-}

--- a/test/main/accounts/index.test.js
+++ b/test/main/accounts/index.test.js
@@ -757,7 +757,7 @@ describe('#resolveRequest', () => {
       throw new Error('unexpected callback!')
     })
 
-    Accounts.resolveRequest({ handlerId: '-1' })
+    Accounts.resolveRequest({ payload: {}, handlerId: '-1' })
 
     expect(Object.keys(Accounts.current().requests)).toHaveLength(1)
   })


### PR DESCRIPTION
Currently the request to add a chain will only be resolved if the user both accepts the request and eventually adds the chain. If the user then chooses not to add the chain or dismisses the add chain dialog the request will never receive a response. This changes the flow so that the request will be resolved as soon as the user accepts it, then they can decide whether or not to edit or add the chain in the future.