### PR TITLE
Fix sentry throw

### DIFF
--- a/main/signers/ledger/Ledger/eth.ts
+++ b/main/signers/ledger/Ledger/eth.ts
@@ -8,6 +8,7 @@ import Eth from '@ledgerhq/hw-app-eth'
 import { Derivation, getDerivationPath, deriveHDAccounts } from '../../Signer/derive'
 import { TransactionData } from '../../../../resources/domain/transaction'
 import { sign } from '../../../transaction'
+import type { DeviceError } from '.'
 
 export default class LedgerEthereumApp {
   private eth: Eth;
@@ -57,7 +58,9 @@ export default class LedgerEthereumApp {
       domainSeparatorHex = TypedDataUtils.hashStruct('EIP712Domain', domain, types).toString('hex')
       hashStructMessageHex = TypedDataUtils.hashStruct(primaryType as string, message, types).toString('hex')
     } catch (e) {
-      throw { statusCode: 99901, message: 'Invalid typed data' }
+      const err = new Error('Invalid typed data') as unknown as DeviceError
+      err.statusCode = 99901
+      throw err
     }
 
     const signature = await this.eth.signEIP712HashedMessage(path, domainSeparatorHex, hashStructMessageHex)

--- a/main/signers/ledger/Ledger/eth.ts
+++ b/main/signers/ledger/Ledger/eth.ts
@@ -58,7 +58,7 @@ export default class LedgerEthereumApp {
       domainSeparatorHex = TypedDataUtils.hashStruct('EIP712Domain', domain, types).toString('hex')
       hashStructMessageHex = TypedDataUtils.hashStruct(primaryType as string, message, types).toString('hex')
     } catch (e) {
-      const err = new Error('Invalid typed data') as unknown as DeviceError
+      const err = new Error('Invalid typed data') as DeviceError
       err.statusCode = 99901
       throw err
     }

--- a/main/signers/ledger/Ledger/eth.ts
+++ b/main/signers/ledger/Ledger/eth.ts
@@ -8,7 +8,7 @@ import Eth from '@ledgerhq/hw-app-eth'
 import { Derivation, getDerivationPath, deriveHDAccounts } from '../../Signer/derive'
 import { TransactionData } from '../../../../resources/domain/transaction'
 import { sign } from '../../../transaction'
-import type { DeviceError } from '.'
+import { DeviceError } from '.'
 
 export default class LedgerEthereumApp {
   private eth: Eth;
@@ -58,9 +58,7 @@ export default class LedgerEthereumApp {
       domainSeparatorHex = TypedDataUtils.hashStruct('EIP712Domain', domain, types).toString('hex')
       hashStructMessageHex = TypedDataUtils.hashStruct(primaryType as string, message, types).toString('hex')
     } catch (e) {
-      const err = new Error('Invalid typed data') as DeviceError
-      err.statusCode = 99901
-      throw err
+      throw new DeviceError('Invalid typed data', 99901)
     }
 
     const signature = await this.eth.signEIP712HashedMessage(path, domainSeparatorHex, hashStructMessageHex)

--- a/main/signers/ledger/Ledger/index.ts
+++ b/main/signers/ledger/Ledger/index.ts
@@ -23,7 +23,7 @@ export const Status = {
   NEEDS_RECONNECTION: 'Please reconnect this Ledger device'
 }
 
-export interface DeviceError {
+export interface DeviceError extends Error {
   statusCode: number,
   message: string
 }

--- a/main/signers/ledger/Ledger/index.ts
+++ b/main/signers/ledger/Ledger/index.ts
@@ -23,7 +23,7 @@ export const Status = {
   NEEDS_RECONNECTION: 'Please reconnect this Ledger device'
 }
 
-interface DeviceError {
+export interface DeviceError {
   statusCode: number,
   message: string
 }

--- a/main/signers/ledger/Ledger/index.ts
+++ b/main/signers/ledger/Ledger/index.ts
@@ -23,11 +23,6 @@ export const Status = {
   NEEDS_RECONNECTION: 'Please reconnect this Ledger device'
 }
 
-export interface DeviceError extends Error {
-  statusCode: number,
-  message: string
-}
-
 interface Address {
   address: string,
   publicKey: string,
@@ -67,6 +62,15 @@ function getStatusForError (err: DeviceError) {
   }
 
   return Status.NEEDS_RECONNECTION
+}
+
+export class DeviceError extends Error {
+  readonly statusCode
+
+  constructor (msg: string, code: number = -1) {
+    super(msg)
+    this.statusCode = code    
+  }
 }
 
 export default class Ledger extends Signer {
@@ -213,14 +217,16 @@ export default class Ledger extends Signer {
 
   private async checkDeviceStatus () {
     const check = new Promise(async (resolve: (err: DeviceError | undefined) => void) => {
-      setTimeout(() => resolve({ statusCode: -1, message: 'status check timed out' }), 3000)
+      setTimeout(() => {
+        resolve(new DeviceError('status check timed out'))
+      }, 3000)
 
       try {
         await this.eth?.getAddress("44'/60'/0'/0", false, false)
         resolve(undefined)
-      } catch (e: unknown) {
-        const err = e as DeviceError
-        resolve({ message: err.message, statusCode: err.statusCode || -1 })
+      } catch (e) {
+        const { message, statusCode } = e as DeviceError
+        resolve(new DeviceError(message, statusCode))
       }
     })
 
@@ -377,7 +383,7 @@ export default class Ledger extends Signer {
             const err = new Error('Address does not match device')
             log.error(err)
 
-            this.handleError({ statusCode: -1, message: 'failed to verify device address' })
+            this.handleError(new DeviceError('failed to verify device address'))
 
             return cb(err, undefined)
           }
@@ -391,7 +397,7 @@ export default class Ledger extends Signer {
 
           // if the address couldn't be verified for any reason the signer can no longer
           // be used, so force it to be closed by setting the status code to unhandled error
-          this.handleError({ message, statusCode: -1 })
+          this.handleError(new DeviceError(message))
           log.error('error verifying message on Ledger', err.toString())
 
           cb(new Error(message), undefined)

--- a/main/signers/ledger/Ledger/index.ts
+++ b/main/signers/ledger/Ledger/index.ts
@@ -67,7 +67,7 @@ function getStatusForError (err: DeviceError) {
 export class DeviceError extends Error {
   readonly statusCode
 
-  constructor (msg: string, code: number = -1) {
+  constructor (msg: string, code = -1) {
     super(msg)
     this.statusCode = code    
   }
@@ -225,8 +225,7 @@ export default class Ledger extends Signer {
         await this.eth?.getAddress("44'/60'/0'/0", false, false)
         resolve(undefined)
       } catch (e) {
-        const { message, statusCode } = e as DeviceError
-        resolve(new DeviceError(message, statusCode))
+        resolve(e as DeviceError)
       }
     })
 

--- a/main/signers/trezor/bridge.ts
+++ b/main/signers/trezor/bridge.ts
@@ -36,7 +36,9 @@ async function handleResponse <T> (p: Response<T>) {
   const response = await p
   
   if (response.success) return response.payload
-  throw { message: response.payload.error, code: response.payload.code }
+  const responseError = new Error(response.payload.error) as NodeJS.ErrnoException
+  responseError.code = response.payload.code
+  throw responseError
 }
 
 class TrezorBridge extends EventEmitter {


### PR DESCRIPTION
Removing the two cases of throwing an object literal instead of an Error