### PR TITLE
return error when EIP-712 typedData submitted without message

### DIFF
--- a/main/provider/index.ts
+++ b/main/provider/index.ts
@@ -553,7 +553,7 @@ export class Provider extends EventEmitter {
     const targetAccount = accounts.get(from.toLowerCase())
 
     if (!targetAccount) {
-      return resError(`unknown account: ${from}`, payload, res)
+      return resError(`Unknown account: ${from}`, payload, res)
     }
 
     // HACK: Standards clearly say, that second param is an object but it seems like in the wild it can be a JSON-string.
@@ -562,12 +562,12 @@ export class Provider extends EventEmitter {
         typedData = JSON.parse(typedData)
         payload.params = [from, typedData, ...additionalParams]
       } catch (e) {
-        return resError('Malformed typedData.', payload, res)
+        return resError('Malformed typed data', payload, res)
       }
     }
     
     if (!Array.isArray(typedData) && !typedData.message) {
-      return resError('TypedData missing message', payload, res)
+      return resError('Typed data missing message', payload, res)
     }
 
     const signerType = getSignerType(targetAccount.lastSignerType)

--- a/main/provider/index.ts
+++ b/main/provider/index.ts
@@ -565,6 +565,10 @@ export class Provider extends EventEmitter {
         return resError('Malformed typedData.', payload, res)
       }
     }
+    
+    if (!Array.isArray(typedData) && !typedData.message) {
+      return resError('TypedData missing message', payload, res)
+    }
 
     const signerType = getSignerType(targetAccount.lastSignerType)
 

--- a/test/main/provider/index.test.js
+++ b/test/main/provider/index.test.js
@@ -1039,11 +1039,21 @@ describe('#send', () => {
       verifyRequest('V1')
     })
 
+    it('does not submit a request without a message', done => {
+      const params = [address, { ...typedData, message: undefined }]
+
+      send({ method: 'eth_signTypedData_v3', params }, err => {
+        expect(err.error.message).toBe('Typed data missing message')
+        expect(err.error.code).toBe(-1)
+        done()
+      })
+    })
+
     it('does not submit a request from an unknown account', done => {
       const params = ['0xa4581bfe76201f3aa147cce8e360140582260441', typedData]
 
       send({ method: 'eth_signTypedData_v3', params }, err => {
-        expect(err.error.message).toBeTruthy()
+        expect(err.error.message).toBe('Unknown account: 0xa4581bfe76201f3aa147cce8e360140582260441')
         expect(err.error.code).toBe(-1)
         done()
       })
@@ -1053,7 +1063,7 @@ describe('#send', () => {
       const params = [address, 'test']
 
       send({ method: 'eth_signTypedData_v3', params }, err => {
-        expect(err.error.message).toBeTruthy()
+        expect(err.error.message).toBe('Malformed typed data')
         expect(err.error.code).toBe(-1)
         done()
       })


### PR DESCRIPTION
The SignTypedDataRequest component is throwing on this `Object.keys()` call:
https://github.com/floating/frame/blob/c54541a7622fa71e0626d1a353ce33e70c3e5253/app/App/Main/Account/Requests/SignTypedDataRequest/index.js#L10

We can either guard against an undefined `message` property or return an error (this PR)