### PR TITLE
Fix zero estimates for polygon

### DIFF
--- a/resources/Components/Gas/index.js
+++ b/resources/Components/Gas/index.js
@@ -76,7 +76,7 @@ const GasFeesMarket = ({ gasPrice, fees: { nextBaseFee, maxPriorityFeePerGas } }
         <div className='gasArrowInner'>{svg.chevron(27)}</div>
       </div>
       <div className='gasGweiNum'>
-        {gasPrice}
+        {gasPrice || '‹0.001'}
       </div >
       <span className='gasGweiLabel'>{'GWEI'}</span>
       <span className='gasLevelLabel'>{'Recommended'}</span>
@@ -183,7 +183,7 @@ class GasSummaryComponent extends Component {
       <>
         <div className='sliceTileGasPrice'> 
           <div className='sliceTileGasPriceIcon'>{svg.gas(9)}</div>
-          <div className='sliceTileGasPriceNumber'>{gasPrice}</div>
+          <div className='sliceTileGasPriceNumber'>{gasPrice || '‹0.001'}</div>
           <div className='sliceTileGasPriceUnit'>{'gwei'}</div>
         </div>
         <div className='sliceGasEstimateBlock'>

--- a/resources/Components/Gas/index.js
+++ b/resources/Components/Gas/index.js
@@ -11,7 +11,6 @@ const gasToSendToken = 65 * 1000
 const gasForDexSwap = 200 * 1000
 
 function roundGwei(gwei) {
-  if (gwei && gwei < 0.001) return '‹0.001'
   return parseFloat(
     gwei >= 10 ? Math.round(gwei) :
     gwei >= 5 ? Math.round(gwei * 10) / 10 :
@@ -62,7 +61,7 @@ const GasFeesMarket = ({ gasPrice, fees: { nextBaseFee, maxPriorityFeePerGas } }
     </div>}
     <div className='gasItem gasItemSmall'>
       <div className='gasGweiNum'>
-        {calculatedFees.actualBaseFee}
+        {calculatedFees.actualBaseFee || '‹0.001'}
       </div >
       <span className='gasGweiLabel'>{'GWEI'}</span>
       <span className='gasLevelLabel'>{'Current Base'}</span>
@@ -91,7 +90,7 @@ const GasFeesMarket = ({ gasPrice, fees: { nextBaseFee, maxPriorityFeePerGas } }
     </div>
     <div className='gasItem gasItemSmall'>
       <div className='gasGweiNum'>
-        {calculatedFees.priorityFee}
+        {calculatedFees.priorityFee || '‹0.001'}
       </div >
       <span className='gasGweiLabel'>{'GWEI'}</span>
       <span className='gasLevelLabel'>{'Priority Tip'}</span>


### PR DESCRIPTION
The small value case '‹0.001' was being returned from the `roundGwei` function, as the function is called twice when calculating the low estimate, this resulted in NaN which was defaulted to zero.