### PR TITLE
always allow providers to connect when Frame is running

### DIFF
--- a/main/provider/helpers.ts
+++ b/main/provider/helpers.ts
@@ -97,6 +97,10 @@ export function isCurrentAccount (address: string, account: FrameAccount | null)
   return address && (accountToCheck.id.toLowerCase() === address.toLowerCase())
 }
   
+export function respondToJsonRPC (id: number, result: unknown, res: RPCRequestCallback, jsonrpc = '2.0') {
+  res({ id, jsonrpc, result })
+}
+  
 export function resError (errorData: string | EVMError, request: RPCId, res: RPCErrorCallback) {
   const error = (typeof errorData === 'string')
     ? { message: errorData, code: -1 }

--- a/main/provider/index.ts
+++ b/main/provider/index.ts
@@ -164,30 +164,6 @@ export class Provider extends EventEmitter {
     this.emit('data:subscription', payload)
   }
 
-  getNetVersion (payload: RPCRequestPayload, res: RPCRequestCallback, targetChain: Chain) {
-    const connection = this.connection.connections[targetChain.type][targetChain.id]
-    const chainConnected = connection && (connection.primary?.connected || connection.secondary?.connected)
-
-    const response = chainConnected
-      ? { result: connection.chainId }
-      : { error: { message: 'not connected', code: 1 } }
-
-    res({ id: payload.id, jsonrpc: payload.jsonrpc, ...response })
-  }
-
-  getChainId (payload: RPCRequestPayload, res: RPCSuccessCallback, targetChain: Chain) {
-    const connection = this.connection.connections[targetChain.type][targetChain.id]
-    const chainConnected = (connection.primary?.connected || connection.secondary?.connected)
-
-    const response = chainConnected
-      ? { result: intToHex(targetChain.id) }
-      : { error: { message: 'not connected', code: 1 } }
-
-      
-
-    res({ id: payload.id, jsonrpc: payload.jsonrpc, ...response })
-  }
-
   declineRequest (req: AccountRequest) {
     const res = (data: any) => {
       if (this.handlers[req.handlerId]) this.handlers[req.handlerId](data)
@@ -715,53 +691,51 @@ export class Provider extends EventEmitter {
       return resError('only ERC-20 tokens are supported', payload, cb)
     }
 
-    this.getChainId(payload, resp => {
-      const chainId = parseInt(resp.result)
+    const chainId = targetChain.id
 
-      const address = (tokenData.address || '').toLowerCase()
-      const symbol = (tokenData.symbol || '').toUpperCase()
-      const decimals = parseInt(tokenData.decimals || '1')
+    const address = (tokenData.address || '').toLowerCase()
+    const symbol = (tokenData.symbol || '').toUpperCase()
+    const decimals = parseInt(tokenData.decimals || '1')
 
-      if (!address) {
-        return resError('tokens must define an address', payload, cb)
-      }
+    if (!address) {
+      return resError('tokens must define an address', payload, cb)
+    }
 
-      const res = () => {
-        cb({ id: payload.id, jsonrpc: '2.0', result: true })
-      }
+    const res = () => {
+      cb({ id: payload.id, jsonrpc: '2.0', result: true })
+    }
 
-      // don't attempt to add the token if it's already been added
-      const tokenExists = store('main.tokens.custom').some((token: Token) => token.chainId === chainId && token.address === address)
-      if (tokenExists) {
-        return res()
-      }
+    // don't attempt to add the token if it's already been added
+    const tokenExists = store('main.tokens.custom').some((token: Token) => token.chainId === chainId && token.address === address)
+    if (tokenExists) {
+      return res()
+    }
 
-      const token = {
-        chainId,
-        name: tokenData.name || capitalize(symbol),
-        address,
-        symbol,
-        decimals,
-        logoURI: tokenData.image || tokenData.logoURI || ''
-      }
+    const token = {
+      chainId,
+      name: tokenData.name || capitalize(symbol),
+      address,
+      symbol,
+      decimals,
+      logoURI: tokenData.image || tokenData.logoURI || ''
+    }
 
-      // const result = {
-      //   suggestedAssetMeta: {
-      //     asset: { token }
-      //   }
-      // }
+    // const result = {
+    //   suggestedAssetMeta: {
+    //     asset: { token }
+    //   }
+    // }
 
-      const handlerId = this.addRequestHandler(res)
+    const handlerId = this.addRequestHandler(res)
 
-      accounts.addRequest({
-        handlerId,
-        type: 'addToken',
-        token,
-        account: (accounts.current() as FrameAccount).id,
-        origin: payload._origin,
-        payload
-      } as AddTokenRequest, res)
-    }, targetChain)
+    accounts.addRequest({
+      handlerId,
+      type: 'addToken',
+      token,
+      account: (accounts.current() as FrameAccount).id,
+      origin: payload._origin,
+      payload
+    } as AddTokenRequest, res)
   }
 
   private parseTargetChain (payload: RPCRequestPayload): Chain {

--- a/main/provider/index.ts
+++ b/main/provider/index.ts
@@ -39,6 +39,7 @@ import {
   requestPermissions,
   resError,
   hasPermission,
+  respondToJsonRPC,
 } from './helpers'
 
 import {
@@ -181,6 +182,8 @@ export class Provider extends EventEmitter {
     const response = chainConnected
       ? { result: intToHex(targetChain.id) }
       : { error: { message: 'not connected', code: 1 } }
+
+      
 
     res({ id: payload.id, jsonrpc: payload.jsonrpc, ...response })
   }
@@ -852,9 +855,8 @@ export class Provider extends EventEmitter {
     if (method === 'wallet_getEthereumChains') return this.getChains(payload, res)
     if (method === 'wallet_getAssets') return this.getAssets(payload as RPC.GetAssets.Request, accounts.current(), res as RPCCallback<RPC.GetAssets.Response>)
 
-    // Connection dependent methods need to pass targetChain
-    if (method === 'net_version') return this.getNetVersion(payload, res, targetChain)
-    if (method === 'eth_chainId') return this.getChainId(payload, res, targetChain)
+    if (method === 'net_version') return respondToJsonRPC(payload.id, targetChain.id, res)
+    if (method === 'eth_chainId') return respondToJsonRPC(payload.id, intToHex(targetChain.id), res)
 
     // remove custom data
     const { _origin, chainId, ...rpcPayload } = payload

--- a/test/main/provider/index.test.js
+++ b/test/main/provider/index.test.js
@@ -83,7 +83,7 @@ describe('#send', () => {
   it('passes the given target chain to the connection', () => {
     connection.connections.ethereum[10] = { chainConfig: { hardfork: 'london', chainId: 10 }, primary: { connected: true } }
 
-    const request = { method: 'eth_testFrame'  }
+    const request = { method: 'eth_testFrame' }
 
     send({ ...request, chainId: '0xa' })
 
@@ -124,7 +124,7 @@ describe('#send', () => {
     it('returns the current chain id from the store', () => {
       store.set('main.networks.ethereum', 1, { id: 1 })
 
-      send({ method: 'eth_chainId', chainId: '0x1' }, response => {
+      send({ method: 'eth_chainId' }, response => {
         expect(response.result).toBe('0x1')
       })
     })
@@ -134,15 +134,6 @@ describe('#send', () => {
 
       send({ method: 'eth_chainId', chainId: '0x4' }, response => {
         expect(response.result).toBe('0x4')
-      })
-    })
-
-    it('returns an error for a disconnected chain', () => {
-      connection.connections.ethereum[11] = { chainConfig: chainConfig(11, 'london'), primary: { connected: false } }
-
-      send({ method: 'eth_chainId', chainId: '0xb' }, response => {
-        expect(response.error.message).toBe('not connected')
-        expect(response.result).toBeUndefined()
       })
     })
   })


### PR DESCRIPTION
When providers attempt to connect to Frame they send `eth_chainId` and `net_version` requests to ensure that the chain is connected. The result of this is that dapps and the extension would consider Frame "not connected" if the current chain was down or turned off. This distinction goes away with omni-chain and so we always want to allow providers to connect to Frame regardless of any chain status.