### PR TITLE
Chain connections panel: fix double disconnect

### DIFF
--- a/dash/App/Chains/Connection/index.js
+++ b/dash/App/Chains/Connection/index.js
@@ -38,7 +38,7 @@ function isConnected ({ status }) {
 }
 
 function getActiveConnection (primary, secondary) {
-  if (secondary.on && (!primary.on || (isConnected(secondary) && !isConnected(primary)))) {
+  if (secondary.on && (!primary.on || !isConnected(primary))) {
     return secondary
   }
 

--- a/main/chains/index.js
+++ b/main/chains/index.js
@@ -287,7 +287,7 @@ class ChainConnection extends EventEmitter {
             this.secondary.status = 'chain mismatch'
             this.update('secondary')
           } else {
-            this.primary.status = status
+            this.secondary.status = status
             this.update('secondary')
           }
         })


### PR DESCRIPTION
Changing the behaviour of the connections panel when both connections fail.

* Secondary connection status now updates correctly
* Overall connection state now takes account of secondary when disconnected

Current behaviour:
```
(Loading) Infura
Primary: Loading - Infura
Secondary: Standby - Custom

(Loading) Custom
Primary: Disconnected - Infura
Secondary: Loading - Custom
```

Desired behaviour:
```
(Loading) Infura
Primary: Loading - Infura
Secondary: Standby - Custom

(Loading) Custom
Primary: Disconnected - Infura
Secondary: Loading - Custom

(Disconnected) Custom
Primary: Disconnected - Infura
Secondary: Disconnected - Custom
```