### PR TITLE
Reset requests on ledger disconnect

### DIFF
--- a/main/accounts/Account/index.ts
+++ b/main/accounts/Account/index.ts
@@ -583,7 +583,7 @@ class FrameAccount {
     }
   }
 
-  signTransaction (rawTx: TransactionData, handlerId: string, cb: Callback<string>) {
+  signTransaction (rawTx: TransactionData, cb: Callback<string>) {
     // if(index === typeof 'object' && cb === typeof 'undefined' && typeof rawTx === 'function') cb = rawTx; rawTx = index; index = 0;
     this.validateTransaction(rawTx, (err) => {
       if (err) return cb(err)

--- a/main/accounts/Account/index.ts
+++ b/main/accounts/Account/index.ts
@@ -575,7 +575,15 @@ class FrameAccount {
     }
   }
 
-  signTransaction (rawTx: TransactionData, cb: Callback<string>) {
+  resetRequest (handlerId: string) {
+    if (this.requests[handlerId]) {
+      this.requests[handlerId].status = undefined
+      this.requests[handlerId].notice = undefined
+      this.update()
+    }
+  }
+
+  signTransaction (rawTx: TransactionData, handlerId: string, cb: Callback<string>) {
     // if(index === typeof 'object' && cb === typeof 'undefined' && typeof rawTx === 'function') cb = rawTx; rawTx = index; index = 0;
     this.validateTransaction(rawTx, (err) => {
       if (err) return cb(err)
@@ -585,7 +593,7 @@ class FrameAccount {
 
         const index = s.addresses.map(a => a.toLowerCase()).indexOf(this.address)
         if (index === -1) cb(new Error(`Signer cannot sign for this address`))
-        s.signTransaction(index, rawTx, cb)
+        s.signTransaction(index, rawTx, cb, () => this.resetRequest(handlerId))
       } else if (this.smart && this.smart.actor) {
         const actingAccount = this.accounts.get(this.smart.actor)
         if (!actingAccount) return cb(new Error(`Could not find acting account: ${this.smart.actor}`))

--- a/main/accounts/Account/index.ts
+++ b/main/accounts/Account/index.ts
@@ -575,7 +575,7 @@ class FrameAccount {
     }
   }
 
-  resetRequest (handlerId: string) {
+  resetRequest ({ handlerId }: AccountRequest) {
     if (this.requests[handlerId]) {
       this.requests[handlerId].status = undefined
       this.requests[handlerId].notice = undefined
@@ -593,7 +593,7 @@ class FrameAccount {
 
         const index = s.addresses.map(a => a.toLowerCase()).indexOf(this.address)
         if (index === -1) cb(new Error(`Signer cannot sign for this address`))
-        s.signTransaction(index, rawTx, cb, () => this.resetRequest(handlerId))
+        s.signTransaction(index, rawTx, cb)
       } else if (this.smart && this.smart.actor) {
         const actingAccount = this.accounts.get(this.smart.actor)
         if (!actingAccount) return cb(new Error(`Could not find acting account: ${this.smart.actor}`))

--- a/main/accounts/index.ts
+++ b/main/accounts/index.ts
@@ -486,7 +486,7 @@ export class Accounts extends EventEmitter {
     currentAccount.signTypedData(version, typedData, cb)
   }
 
-  signTransaction (rawTx: TransactionData, handlerId: string, cb: Callback<string>) {
+  signTransaction (rawTx: TransactionData, cb: Callback<string>) {
     const currentAccount = this.current()
 
     if (!currentAccount) return cb(new Error('No Account Selected'))
@@ -495,7 +495,7 @@ export class Accounts extends EventEmitter {
     const matchActor = (rawTx.from || '').toLowerCase() === (currentAccount.smart ? currentAccount.smart.actor.toLowerCase() : false)
     
     if (matchSelected || matchActor) {
-      currentAccount.signTransaction(rawTx, handlerId, cb)
+      currentAccount.signTransaction(rawTx, cb)
     } else {
       cb(new Error('signMessage: Account does not match currently selected'))
     }

--- a/main/accounts/index.ts
+++ b/main/accounts/index.ts
@@ -486,7 +486,7 @@ export class Accounts extends EventEmitter {
     currentAccount.signTypedData(version, typedData, cb)
   }
 
-  signTransaction (rawTx: TransactionData, cb: Callback<string>) {
+  signTransaction (rawTx: TransactionData, handlerId: string, cb: Callback<string>) {
     const currentAccount = this.current()
 
     if (!currentAccount) return cb(new Error('No Account Selected'))
@@ -495,7 +495,7 @@ export class Accounts extends EventEmitter {
     const matchActor = (rawTx.from || '').toLowerCase() === (currentAccount.smart ? currentAccount.smart.actor.toLowerCase() : false)
     
     if (matchSelected || matchActor) {
-      currentAccount.signTransaction(rawTx, cb)
+      currentAccount.signTransaction(rawTx, handlerId, cb)
     } else {
       cb(new Error('signMessage: Account does not match currently selected'))
     }
@@ -596,6 +596,7 @@ export class Accounts extends EventEmitter {
     const currentAccount = this.current()
     
     log.info('setRequestPending', handlerId)
+    console.log('setRequestPending', req, currentAccount?.requests[handlerId])
 
     if (currentAccount && currentAccount.requests[handlerId]) {
       currentAccount.requests[handlerId].status = RequestStatus.Pending

--- a/main/accounts/index.ts
+++ b/main/accounts/index.ts
@@ -550,6 +550,13 @@ export class Accounts extends EventEmitter {
     }
   }
 
+  resetRequest (req: AccountRequest) {
+    const currentAccount = this.current()
+    if (currentAccount) {
+      currentAccount.resetRequest(req)
+    }
+  }
+
   addRequest (req: AccountRequest, res?: RPCCallback<any>) {
     log.info('addRequest', JSON.stringify(req))
 

--- a/main/provider/index.ts
+++ b/main/provider/index.ts
@@ -312,7 +312,7 @@ export class Provider extends EventEmitter {
       resError(err, payload, res)
       cb(new Error(err))
     } else {
-      accounts.signTransaction(rawTx, req.handlerId, (err, signedTx) => { // Sign Transaction
+      accounts.signTransaction(rawTx, (err, signedTx) => { // Sign Transaction
         if (err && err.message === 'Device disconnected') {
           accounts.resetRequest(req)
         } else if (err) {  

--- a/main/provider/index.ts
+++ b/main/provider/index.ts
@@ -313,7 +313,9 @@ export class Provider extends EventEmitter {
       cb(new Error(err))
     } else {
       accounts.signTransaction(rawTx, req.handlerId, (err, signedTx) => { // Sign Transaction
-        if (err) {
+        if (err && err.message === 'Device disconnected') {
+          accounts.resetRequest(req)
+        } else if (err) {  
           resError(err, payload, res)
           cb(err)
         } else {

--- a/main/provider/index.ts
+++ b/main/provider/index.ts
@@ -312,7 +312,7 @@ export class Provider extends EventEmitter {
       resError(err, payload, res)
       cb(new Error(err))
     } else {
-      accounts.signTransaction(rawTx, (err, signedTx) => { // Sign Transaction
+      accounts.signTransaction(rawTx, req.handlerId, (err, signedTx) => { // Sign Transaction
         if (err) {
           resError(err, payload, res)
           cb(err)
@@ -351,7 +351,7 @@ export class Provider extends EventEmitter {
   }
 
   approveTransactionRequest (req: TransactionRequest, cb: Callback<string>) {
-    log.info('approveRequest', req)
+    console.log('approveRequest', req)
 
     accounts.lockRequest(req.handlerId)
     if (req.data.nonce) return this.signAndSend(req, cb)

--- a/main/signers/Signer/index.ts
+++ b/main/signers/Signer/index.ts
@@ -104,7 +104,7 @@ export default class Signer extends EventEmitter {
     console.warn('Signer:' + this.type + ' did not implement a signMessage method')
   }
 
-  signTransaction (index: number, rawTx: TransactionData, cb: Callback<string>, resetCb = () => {}) {
+  signTransaction (index: number, rawTx: TransactionData, cb: Callback<string>) {
     console.warn('Signer:' + this.type + ' did not implement a signTransaction method')
   }
 

--- a/main/signers/Signer/index.ts
+++ b/main/signers/Signer/index.ts
@@ -104,7 +104,7 @@ export default class Signer extends EventEmitter {
     console.warn('Signer:' + this.type + ' did not implement a signMessage method')
   }
 
-  signTransaction (index: number, rawTx: TransactionData, cb: Callback<string>) {
+  signTransaction (index: number, rawTx: TransactionData, cb: Callback<string>, resetCb = () => {}) {
     console.warn('Signer:' + this.type + ' did not implement a signTransaction method')
   }
 

--- a/main/signers/ledger/Ledger/index.ts
+++ b/main/signers/ledger/Ledger/index.ts
@@ -477,7 +477,7 @@ export default class Ledger extends Signer {
     })
   }
 
-  signTransaction (index: number, rawTx: TransactionData, cb: Callback<string>) {
+  signTransaction (index: number, rawTx: TransactionData, cb: Callback<string>, resetCb: () => void) {
     const compatibility = signerCompatibility(rawTx, this.summary())
     const ledgerTx = compatibility.compatible ? { ...rawTx } : londonToLegacy(rawTx)
 
@@ -505,7 +505,7 @@ export default class Ledger extends Signer {
         }
       },
       abort: (message) => {
-        cb(new Error(message), undefined)
+        resetCb()
       }
     })
   }

--- a/main/signers/ledger/Ledger/index.ts
+++ b/main/signers/ledger/Ledger/index.ts
@@ -155,7 +155,7 @@ export default class Ledger extends Signer {
       this.emit('update')
     }
 
-    this.requestQueue.close('Ledger disconnected')
+    this.requestQueue.close('Device disconnected')
 
     clearTimeout(this.statusPoller)
 
@@ -267,7 +267,7 @@ export default class Ledger extends Signer {
 
             return this.checkDeviceStatus()
           },
-          abort: () => {}
+          reset: () => {}
         })
       }
 
@@ -332,7 +332,7 @@ export default class Ledger extends Signer {
             this.handleError(e as DeviceError)
           }
         },
-        abort: () => { }
+        reset: () => { }
       })
     }
 
@@ -365,7 +365,7 @@ export default class Ledger extends Signer {
           this.handleError(e as DeviceError)
         }
       },
-      abort: () => { }
+      reset: () => { }
     })
   }
 
@@ -405,7 +405,7 @@ export default class Ledger extends Signer {
           cb(new Error(message), undefined)
         }
       },
-      abort: (message) => {
+      reset: (message) => {
         cb(new Error(message), undefined)
       }
     })
@@ -435,7 +435,7 @@ export default class Ledger extends Signer {
           cb(new Error(message), undefined)
         }
       },
-      abort: (message) => {
+      reset: (message) => {
         cb(new Error(message), undefined)
       }
     })
@@ -471,13 +471,13 @@ export default class Ledger extends Signer {
           cb(new Error(message), undefined)
         }
       },
-      abort: (message) => {
+      reset: (message) => {
         cb(new Error(message), undefined)
       }
     })
   }
 
-  signTransaction (index: number, rawTx: TransactionData, cb: Callback<string>, resetCb: () => void) {
+  signTransaction (index: number, rawTx: TransactionData, cb: Callback<string>) {
     const compatibility = signerCompatibility(rawTx, this.summary())
     const ledgerTx = compatibility.compatible ? { ...rawTx } : londonToLegacy(rawTx)
 
@@ -504,8 +504,8 @@ export default class Ledger extends Signer {
           cb(new Error(message), undefined)
         }
       },
-      abort: (message) => {
-        resetCb()
+      reset: (message) => {
+        cb(new Error(message), undefined)
       }
     })
   }

--- a/main/signers/ledger/Ledger/index.ts
+++ b/main/signers/ledger/Ledger/index.ts
@@ -155,7 +155,7 @@ export default class Ledger extends Signer {
       this.emit('update')
     }
 
-    this.requestQueue.close()
+    this.requestQueue.close('Ledger disconnected')
 
     clearTimeout(this.statusPoller)
 
@@ -266,7 +266,8 @@ export default class Ledger extends Signer {
             }
 
             return this.checkDeviceStatus()
-          }
+          },
+          abort: () => {}
         })
       }
 
@@ -289,7 +290,7 @@ export default class Ledger extends Signer {
   // *** request enqueuing methods *** //
 
   deriveAddresses () {
-    this.requestQueue.clear()
+    this.requestQueue.clear('Ledger deriving addresses')
     this.addresses = []
 
     this.updateStatus(Status.DERIVING)
@@ -303,7 +304,7 @@ export default class Ledger extends Signer {
   }
 
   private deriveLiveAddresses () {
-    const requests = []
+    const requests: Request[] = []
 
     for (let i = 0; i < this.accountLimit; i++) {
       requests.push({
@@ -330,7 +331,8 @@ export default class Ledger extends Signer {
           } catch (e) {
             this.handleError(e as DeviceError)
           }
-        }
+        },
+        abort: () => { }
       })
     }
 
@@ -362,7 +364,8 @@ export default class Ledger extends Signer {
         } catch (e) {
           this.handleError(e as DeviceError)
         }
-      }
+      },
+      abort: () => { }
     })
   }
 
@@ -401,6 +404,9 @@ export default class Ledger extends Signer {
 
           cb(new Error(message), undefined)
         }
+      },
+      abort: (message) => {
+        cb(new Error(message), undefined)
       }
     })
   }
@@ -428,6 +434,9 @@ export default class Ledger extends Signer {
 
           cb(new Error(message), undefined)
         }
+      },
+      abort: (message) => {
+        cb(new Error(message), undefined)
       }
     })
   }
@@ -461,6 +470,9 @@ export default class Ledger extends Signer {
 
           cb(new Error(message), undefined)
         }
+      },
+      abort: (message) => {
+        cb(new Error(message), undefined)
       }
     })
   }
@@ -491,6 +503,9 @@ export default class Ledger extends Signer {
 
           cb(new Error(message), undefined)
         }
+      },
+      abort: (message) => {
+        cb(new Error(message), undefined)
       }
     })
   }

--- a/main/signers/ledger/Ledger/requestQueue.ts
+++ b/main/signers/ledger/Ledger/requestQueue.ts
@@ -1,7 +1,7 @@
 import log from 'electron-log'
 
 export interface Request {
-  abort: (message: string) => void
+  reset: (message: string) => void
   execute: () => Promise<any>,
   type: string
 }
@@ -51,7 +51,7 @@ export class RequestQueue {
   }
 
   clear (message: string) {
-    this.requestQueue.forEach((request) => request.abort(message))
+    this.requestQueue.forEach((request) => request.reset(message))
     this.requestQueue = []
   }
 

--- a/main/signers/ledger/Ledger/requestQueue.ts
+++ b/main/signers/ledger/Ledger/requestQueue.ts
@@ -41,8 +41,8 @@ export class RequestQueue {
   }
   
   stop () {
-    this.running = false
     clearTimeout(this.requestPoller)
+    this.running = false
   }
 
   close (message: string) {

--- a/main/signers/ledger/Ledger/requestQueue.ts
+++ b/main/signers/ledger/Ledger/requestQueue.ts
@@ -1,6 +1,7 @@
 import log from 'electron-log'
 
 export interface Request {
+  abort: (message: string) => void
   execute: () => Promise<any>,
   type: string
 }
@@ -44,12 +45,13 @@ export class RequestQueue {
     clearTimeout(this.requestPoller)
   }
 
-  close () {
+  close (message: string) {
     this.stop()
-    this.clear()
+    this.clear(message)
   }
 
-  clear () {
+  clear (message: string) {
+    this.requestQueue.forEach((request) => request.abort(message))
     this.requestQueue = []
   }
 

--- a/test/main/signers/ledger/Ledger/index.test.js
+++ b/test/main/signers/ledger/Ledger/index.test.js
@@ -273,7 +273,7 @@ describe('#verifyAddress', () => {
     },
     {
       testCase: 'the device is disconnected',
-      expectedError: 'Ledger disconnected',
+      expectedError: 'Device disconnected',
       expectedStatus: Status.DISCONNECTED,
       postExec: () => ledger.disconnect()
     }
@@ -370,7 +370,7 @@ signingMethods.forEach(signingMethod => {
       },
       {
         testCase: 'the device is disconnected',
-        expectedError: 'Ledger disconnected',
+        expectedError: 'Device disconnected',
         expectedStatus: Status.DISCONNECTED,
         postExec: () => ledger.disconnect()
       }
@@ -492,7 +492,7 @@ describe('#signTypedData', () => {
     },
     {
       testCase: 'the device is disconnected',
-      expectedError: 'Ledger disconnected',
+      expectedError: 'Device disconnected',
       expectedStatus: Status.DISCONNECTED,
       postExec: () => ledger.disconnect()
     }

--- a/test/main/signers/ledger/Ledger/index.test.js
+++ b/test/main/signers/ledger/Ledger/index.test.js
@@ -270,14 +270,20 @@ describe('#verifyAddress', () => {
     {
       testCase: 'the derivation type is not initialized',
       setup: () => ledger.derivation = undefined
+    },
+    {
+      testCase: 'the device is disconnected',
+      expectedError: 'Ledger disconnected',
+      expectedStatus: Status.DISCONNECTED,
+      postExec: () => ledger.disconnect()
     }
   ]
 
-  errorCases.forEach(({ testCase, setup = () => {}, expectedError = 'Verify address error' }) => {
+  errorCases.forEach(({ testCase, expectedStatus = Status.NEEDS_RECONNECTION, setup = () => {}, postExec = () => {}, expectedError = 'Verify address error' }) => {
     it(`fails if ${testCase}`, async () => {
       const statusUpdate = new Promise((resolve, reject) => {
         ledger.on('update', () => {
-          verifyPromise(resolve, reject, () => expect(ledger.status).toBe(Status.NEEDS_RECONNECTION))
+          verifyPromise(resolve, reject, () => expect(ledger.status).toBe(expectedStatus))
         })
       })
 
@@ -290,6 +296,8 @@ describe('#verifyAddress', () => {
             expect(err.message).toBe(expectedError)
           })
         })
+
+        postExec()
       })
 
       runNextRequest()
@@ -359,14 +367,20 @@ signingMethods.forEach(signingMethod => {
       {
         testCase: 'the derivation type is not initialized',
         setup: () => ledger.derivation = undefined
+      },
+      {
+        testCase: 'the device is disconnected',
+        expectedError: 'Ledger disconnected',
+        expectedStatus: Status.DISCONNECTED,
+        postExec: () => ledger.disconnect()
       }
     ]
 
-    errorCases.forEach(({ testCase, setup = () => {} }) => {
+    errorCases.forEach(({ testCase, expectedError = `Sign ${signType} error`, expectedStatus = Status.NEEDS_RECONNECTION, setup = () => {}, postExec = () => {} }) => {
       it(`fails if ${testCase}`, async () => {
         const statusUpdate = new Promise((resolve, reject) => {
           ledger.on('update', () => {
-            verifyPromise(resolve, reject, () => expect(ledger.status).toBe(Status.NEEDS_RECONNECTION))
+            verifyPromise(resolve, reject, () => expect(ledger.status).toBe(expectedStatus))
           })
         })
 
@@ -376,9 +390,11 @@ signingMethods.forEach(signingMethod => {
           ledger[signingMethod](3, 'hello, Frame!', (err, signature) => {
             verifyPromise(resolve, reject, () => {
               expect(signature).toBeUndefined()
-              expect(err.message).toBe(`Sign ${signType} error`)
+              expect(err.message).toBe(expectedError)
             })
           })
+
+          postExec()
         })
 
         runNextRequest()
@@ -473,14 +489,20 @@ describe('#signTypedData', () => {
     {
       testCase: 'the derivation type is not initialized',
       setup: () => ledger.derivation = undefined
+    },
+    {
+      testCase: 'the device is disconnected',
+      expectedError: 'Ledger disconnected',
+      expectedStatus: Status.DISCONNECTED,
+      postExec: () => ledger.disconnect()
     }
   ]
 
-  errorCases.forEach(({ testCase, setup = () => {} }) => {
+  errorCases.forEach(({ testCase, expectedError = /Sign message error/, expectedStatus = Status.NEEDS_RECONNECTION, setup = () => {}, postExec = () => {} }) => {
     it(`fails if ${testCase}`, async () => {
       const statusUpdate = new Promise((resolve, reject) => {
         ledger.on('update', () => {
-          verifyPromise(resolve, reject, () => expect(ledger.status).toBe(Status.NEEDS_RECONNECTION))
+          verifyPromise(resolve, reject, () => expect(ledger.status).toBe(expectedStatus))
         })
       })
 
@@ -490,9 +512,11 @@ describe('#signTypedData', () => {
         ledger.signTypedData(5, 'V4', 'typed data', (err, signature) => {
           verifyPromise(resolve, reject, () => {
             expect(signature).toBeUndefined()
-            expect(err.message).toMatch(/Sign message error/)
+            expect(err.message).toMatch(expectedError)
           })
         })
+
+        postExec()
       })
 
       runNextRequest()


### PR DESCRIPTION
* resetting queued requests when a ledger device is disconnected

TODO:
- [x] Fix tests
- [ ] Pass custom error and switch on type instead of message
- [ ] Ensure all possible request types are handled
- [ ] Consider Trezor and Lattice usage
- [ ] Consider locked transaction requests
- [ ] Expand tests