### PR TITLE
System tray menu & window behaviour tweaks

### DIFF
--- a/main/index.ts
+++ b/main/index.ts
@@ -328,6 +328,7 @@ app.on('ready', () => {
       windows.showDash()
     } else {
       windows.hideDash()
+      windows.focusTray()
     }
   })
   store.observer(() => {

--- a/main/windows/extractColors/index.ts
+++ b/main/windows/extractColors/index.ts
@@ -104,7 +104,7 @@ async function extractColors (url: string, ens: string) {
 
   view.webContents.on('will-navigate', e => e.preventDefault())
   view.webContents.on('will-attach-webview', e => e.preventDefault())
-  view.webContents.on('new-window', e => e.preventDefault())
+  view.webContents.setWindowOpenHandler(() => ({ action: 'deny' }))
 
   view.webContents.session.webRequest.onBeforeSendHeaders((details, cb) => {
     if (!details || !details.frame) return cb({ cancel: true }) // Reject the request

--- a/main/windows/frames/viewInstances.ts
+++ b/main/windows/frames/viewInstances.ts
@@ -34,7 +34,7 @@ export default {
   
     viewInstance.webContents.on('will-navigate', e => e.preventDefault())
     viewInstance.webContents.on('will-attach-webview', e => e.preventDefault())
-    viewInstance.webContents.on('new-window', e => e.preventDefault())
+    viewInstance.webContents.setWindowOpenHandler(() => ({ action: 'deny' }))
 
     const { session } = extract(view.url)
 

--- a/main/windows/index.ts
+++ b/main/windows/index.ts
@@ -151,7 +151,7 @@ function initTrayWindow () {
   windows.tray.on('closed', () => delete windows.tray)
   windows.tray.webContents.on('will-navigate', e => e.preventDefault()) // Prevent navigation
   windows.tray.webContents.on('will-attach-webview', e => e.preventDefault()) // Prevent attaching <webview>
-  windows.tray.webContents.on('new-window', e => e.preventDefault()) // Prevent new windows
+  windows.tray.webContents.setWindowOpenHandler(() => ({ action: 'deny' })) // Prevent new windows
   windows.tray.webContents.session.setPermissionRequestHandler((webContents, permission, res) => res(false))
   windows.tray.setResizable(false)
   windows.tray.setMovable(false)
@@ -373,7 +373,7 @@ ipcMain.on('tray:mouseout', () => {
 app.on('web-contents-created', (_e, contents) => {
   contents.on('will-navigate', e => e.preventDefault())
   contents.on('will-attach-webview', e => e.preventDefault())
-  contents.on('new-window', e => e.preventDefault())
+  contents.setWindowOpenHandler(() => ({ action: 'deny' }))
 })
 
 app.on('ready', () => {

--- a/main/windows/index.ts
+++ b/main/windows/index.ts
@@ -161,26 +161,20 @@ function initTrayWindow () {
   windows.tray.setPosition(width + x, height + y)
 
   windows.tray.on('show', () => {
-    // if (process.platform === 'win32') {
-    //   tray.electronTray.off('click', showFrame)
-    //   tray.electronTray.on('click', hideFrame)
-    // }
     if (process.platform === 'win32') {
       tray.electronTray.closeContextMenu()
     }
-    tray.electronTray.setContextMenu(hideMenu)
-    // tray.electronTray.popUpContextMenu()
+    setTimeout(() => {
+      tray.electronTray.setContextMenu(hideMenu)
+    }, 100)
   })
   windows.tray.on('hide', () => {
-    // if (process.platform === 'win32') {
-    //   tray.electronTray.off('click', hideFrame)
-    //   tray.electronTray.on('click', showFrame)
-    // }
     if (process.platform === 'win32') {
       tray.electronTray.closeContextMenu()
     }
-    tray.electronTray.setContextMenu(showMenu)
-    // tray.electronTray.popUpContextMenu()
+    setTimeout(() => {
+      tray.electronTray.setContextMenu(showMenu)
+    }, 100)
   })
 
   setTimeout(() => {
@@ -194,10 +188,7 @@ function initTrayWindow () {
   setTimeout(() => {
     windows.tray.on('blur', () => {
       setTimeout(() => {
-        const frameShowing = frameManager.isFrameShowing()
-        console.log('blur', frameShowing, tray.canAutoHide())
-        if (!frameShowing && tray.canAutoHide() && store('main.autohide') && !store('windows.dash.showing')) {
-          console.log('autohide')
+        if (tray.canAutoHide()) {
           tray.hide(true)
         }
       }, 100)
@@ -243,11 +234,9 @@ class Tray {
     })
     this.readyHandler = () => {
       this.electronTray.on('click', () => {
-        console.log('recent tray click')
         this.recentElectronTrayClick = true
         clearTimeout(this.recentElectronTrayClickTimeout as NodeJS.Timeout)
         this.recentElectronTrayClickTimeout = setTimeout(() => {
-          console.log('recent tray click timed out')
           this.recentElectronTrayClick = false
         }, 50);
         if (process.platform === 'win32') {
@@ -277,7 +266,7 @@ class Tray {
   }
 
   canAutoHide () {
-    return !this.recentElectronTrayClick
+    return !this.recentElectronTrayClick && store('main.autohide') && !store('windows.dash.showing') && frameManager.isFrameShowing()
   }
 
   hide (autohide: boolean = false) {

--- a/main/windows/index.ts
+++ b/main/windows/index.ts
@@ -150,9 +150,6 @@ function initTrayWindow () {
 
   windows.tray.on('show', () => {
     if (process.platform === 'win32') {
-      tray.electronTray.off('mouse-down', showFrame)
-      tray.electronTray.on('mouse-down', hideFrame)
-    } else {
       tray.electronTray.off('click', showFrame)
       tray.electronTray.on('click', hideFrame)
     }
@@ -167,9 +164,6 @@ function initTrayWindow () {
   })
   windows.tray.on('hide', () => {
     if (process.platform === 'win32') {
-      tray.electronTray.off('mouse-down', hideFrame)
-      tray.electronTray.on('mouse-down', showFrame)
-    } else {
       tray.electronTray.off('click', hideFrame)
       tray.electronTray.on('click', showFrame)
     }

--- a/main/windows/index.ts
+++ b/main/windows/index.ts
@@ -266,17 +266,17 @@ class Tray {
   }
 
   canAutoHide () {
-    return !this.recentElectronTrayClick && store('main.autohide') && !store('windows.dash.showing') && frameManager.isFrameShowing()
+    return !this.recentElectronTrayClick && store('main.autohide') && !store('windows.dash.showing') && !frameManager.isFrameShowing()
   }
 
   hide (autohide: boolean = false) {
     store.toggleDash('hide');
     if (autohide) {
-        this.recentAutohide = true;
-        clearTimeout(this.recentAutoHideTimeout as NodeJS.Timeout);
-        this.recentAutoHideTimeout = setTimeout(() => {
-            this.recentAutohide = false;
-        }, 50);
+      this.recentAutohide = true;
+      clearTimeout(this.recentAutoHideTimeout as NodeJS.Timeout);
+      this.recentAutoHideTimeout = setTimeout(() => {
+        this.recentAutohide = false;
+      }, 50);
     }
 
     if (windows && windows.tray) {

--- a/main/windows/index.ts
+++ b/main/windows/index.ts
@@ -270,13 +270,13 @@ class Tray {
   }
 
   hide (autohide: boolean = false) {
-    store.toggleDash('hide');
+    store.toggleDash('hide')
     if (autohide) {
-      this.recentAutohide = true;
-      clearTimeout(this.recentAutoHideTimeout as NodeJS.Timeout);
+      this.recentAutohide = true
+      clearTimeout(this.recentAutoHideTimeout as NodeJS.Timeout)
       this.recentAutoHideTimeout = setTimeout(() => {
-        this.recentAutohide = false;
-      }, 50);
+        this.recentAutohide = false
+      }, 50)
     }
 
     if (windows && windows.tray) {

--- a/main/windows/index.ts
+++ b/main/windows/index.ts
@@ -238,7 +238,7 @@ class Tray {
         clearTimeout(this.recentElectronTrayClickTimeout as NodeJS.Timeout)
         this.recentElectronTrayClickTimeout = setTimeout(() => {
           this.recentElectronTrayClick = false
-        }, 50);
+        }, 50)
         if (process.platform === 'win32') {
           this.toggle()
         }

--- a/main/windows/index.ts
+++ b/main/windows/index.ts
@@ -455,6 +455,9 @@ export default {
   hideDash () {
     dash.hide()
   },
+  focusTray () {
+    windows.tray.focus()
+  },
   refocusFrame (frameId: string) {
     frameManager.refocus(frameId)
   },

--- a/main/windows/index.ts
+++ b/main/windows/index.ts
@@ -165,7 +165,9 @@ function initTrayWindow () {
     //   tray.electronTray.off('click', showFrame)
     //   tray.electronTray.on('click', hideFrame)
     // }
-    tray.electronTray.closeContextMenu()
+    if (process.platform === 'win32') {
+      tray.electronTray.closeContextMenu()
+    }
     tray.electronTray.setContextMenu(hideMenu)
     // tray.electronTray.popUpContextMenu()
   })
@@ -174,7 +176,9 @@ function initTrayWindow () {
     //   tray.electronTray.off('click', hideFrame)
     //   tray.electronTray.on('click', showFrame)
     // }
-    tray.electronTray.closeContextMenu()
+    if (process.platform === 'win32') {
+      tray.electronTray.closeContextMenu()
+    }
     tray.electronTray.setContextMenu(showMenu)
     // tray.electronTray.popUpContextMenu()
   })
@@ -231,13 +235,12 @@ class Tray {
       }
       this.electronTray.setTitle(title)
     })
-    const windowsTrayClickHandler = () => {
-      // this.electronTray.closeContextMenu()
-      this.toggle()
-      // this.electronTray.popUpContextMenu()
-    }  
     this.readyHandler = () => {
-      this.electronTray.on('click', windowsTrayClickHandler)
+      this.electronTray.on('click', () => {
+        if (process.platform === 'win32') {
+          this.toggle()
+        }
+      })
       if (showOnReady) {
         store.trayOpen(true)
       }


### PR DESCRIPTION
* Enabling summon / hide on Windows when the tray icon is (left-)clicked as the tray menu is accessed via context menu on that platform.
* Ensuring autoHide plays nicely with the new behaviour on Windows.
* Adding 100ms timeout for switching the context menu items - it looked ugly on Ubuntu due to slow menu fade on clicking an item
* Switching the deprecated webContents.on('new-window') approach for denying new windows to use setWindowOpenHandler: https://www.electronjs.org/docs/latest/api/web-contents#contentssetwindowopenhandlerhandler
* The main "Tray" window of Frame is now focussed when the "Dash" window is closed.
