### PR TITLE
Fix windows icon for Send Dapp

### DIFF
--- a/electron-builder.json
+++ b/electron-builder.json
@@ -25,7 +25,8 @@
     },
     "win": {
       "publisherName": "Frame Labs, Inc.",
-      "signAndEditExecutable": true
+      "signAndEditExecutable": true,
+      "icon": "build/icon/icon.png"
     },
     "files": [
       "compiled",

--- a/electron-builder.json
+++ b/electron-builder.json
@@ -26,7 +26,7 @@
     "win": {
       "publisherName": "Frame Labs, Inc.",
       "signAndEditExecutable": true,
-      "icon": "build/icon/icon.png"
+      "icon": "build/icons/icon.png"
     },
     "files": [
       "compiled",


### PR DESCRIPTION
Fixing the send dapp icon display issue. Tested as working with production and canary icons on Win10.

To test / reproduce (Win10):
* Copy icon files from production Frame into `build/icons`
* Build and run Frame
* Open the send dapp
* Observe cut-off icon for the send dapp in the taskbar

Reference for approach:
https://github.com/electron-userland/electron-builder/issues/2128#issuecomment-411797743

