### PR TITLE
fix broken tx chainName on Sepolia

### DIFF
--- a/app/App/Account/Account/Requests/TransactionRequest/TxMain/index.js
+++ b/app/App/Account/Account/Requests/TransactionRequest/TxMain/index.js
@@ -30,8 +30,7 @@ class TxSending extends React.Component {
     const value = req.data.value || '0x'
     const displayValue = this.hexToDisplayValue(value)
     const currentSymbol = this.store('main.networks', this.props.chain.type, this.props.chain.id, 'symbol') || '?'
-    const chainId = parseInt(this.props.chain.id, 16)
-    const chainName = this.store('main.networks.ethereum', chainId, 'name')
+    const chainName = this.store('main.networks.ethereum', this.props.chain.id, 'name')
     if (value === '0x' || parseInt(value, 16) === 0) return null
     return (
       <div className='_txMain' style={{ animationDelay: (0.1 * this.props.i) + 's' }}>


### PR DESCRIPTION
TxMain component is parsing a value which is already an integer, which is fine for e.g. Mainnet and Görli but broken for everything else.

parseInt(1, 16) = 1
parseInt(5, 16) = 5
parseInt(10, 16) = 16
parseInt(42161, 16) = 270689
parseInt(11155111, 16) = 286609681

Tested fix with transactions on Mainnet and Sepolia.