### PR TITLE
better priority fee gas calculation

### DIFF
--- a/main/chains/index.js
+++ b/main/chains/index.js
@@ -82,7 +82,6 @@ class ChainConnection extends EventEmitter {
         try {
           // only consider this an EIP-1559 block if fee market can be loaded
           feeMarket = await gasCalculator.getFeePerGas()
-          console.log({ feeMarket })
 
           this.chainConfig.setHardforkByBlockNumber(block.number)
 

--- a/main/chains/index.js
+++ b/main/chains/index.js
@@ -82,6 +82,7 @@ class ChainConnection extends EventEmitter {
         try {
           // only consider this an EIP-1559 block if fee market can be loaded
           feeMarket = await gasCalculator.getFeePerGas()
+          console.log({ feeMarket })
 
           this.chainConfig.setHardforkByBlockNumber(block.number)
 

--- a/main/transaction/gasCalculator.ts
+++ b/main/transaction/gasCalculator.ts
@@ -51,7 +51,7 @@ export default class GasCalculator {
     // these strategies will be tried in descending order until one finds
     // at least 1 eligible block from which to calculate the reward
     const rewardCalculationStrategies = [
-      // use recent blocks (last 10) that weren't almost empty or almost full
+      // use recent blocks that weren't almost empty or almost full
       { minRatio: 0.1, maxRatio: 0.9, blockSampleSize: recentBlocks },
       // include recent blocks that were full
       { minRatio: 0.1, maxRatio: 1.05, blockSampleSize: recentBlocks },

--- a/main/transaction/gasCalculator.ts
+++ b/main/transaction/gasCalculator.ts
@@ -45,19 +45,22 @@ export default class GasCalculator {
   }
 
   private calculateReward (blocks: Block[]) {
+    const recentBlocks = 10
+    const allBlocks = blocks.length
+
     // these strategies will be tried in descending order until one finds
     // at least 1 eligible block from which to calculate the reward
     const rewardCalculationStrategies = [
       // use recent blocks (last 10) that weren't almost empty or almost full
-      { minRatio: 0.1, maxRatio: 0.9, blockSampleSize: 11 },
+      { minRatio: 0.1, maxRatio: 0.9, blockSampleSize: recentBlocks },
       // include recent blocks that were full
-      { minRatio: 0.1, maxRatio: 1, blockSampleSize: 11 },
+      { minRatio: 0.1, maxRatio: 1.05, blockSampleSize: recentBlocks },
       // use the entire block sample but still limit to blocks that were not almost empty
-      { minRatio: 0.1, maxRatio: 1, blockSampleSize: blocks.length },
+      { minRatio: 0.1, maxRatio: 1.05, blockSampleSize: allBlocks },
       // use any recent block with transactions
-      { minRatio: 0, maxRatio: Number.MAX_SAFE_INTEGER, blockSampleSize: 11 },
+      { minRatio: 0, maxRatio: Number.MAX_SAFE_INTEGER, blockSampleSize: recentBlocks },
       // use any block with transactions
-      { minRatio: 0, maxRatio: Number.MAX_SAFE_INTEGER, blockSampleSize: blocks.length }
+      { minRatio: 0, maxRatio: Number.MAX_SAFE_INTEGER, blockSampleSize: allBlocks }
     ]
 
     const eligibleRewardsBlocks = rewardCalculationStrategies.reduce((foundBlocks, strategy) => {

--- a/main/transaction/gasCalculator.ts
+++ b/main/transaction/gasCalculator.ts
@@ -1,40 +1,23 @@
 import { intToHex } from 'ethereumjs-util'
 
-// TODO: move these to a declaration file?
 interface FeeHistoryResponse {
-  baseFeePerGas: string[],
-  gasUsedRatio: number[],
-  reward: Array<string[]>,
+  baseFeePerGas: string[]
+  gasUsedRatio: number[]
+  reward: Array<string[]>
   oldestBlock: string
 }
 
-interface ProviderRequest {
-  method: string,
-  params: any[],
-  id: number,
-  jsonrpc: '2.0'
-}
-
 interface Block {
-  baseFee: number,
-  rewards: number[],
+  baseFee: number
+  rewards: number[]
   gasUsedRatio: number
 }
 
 interface GasPrices {
-  slow: string,
-  standard: string,
-  fast: string,
+  slow: string
+  standard: string
+  fast: string
   asap: string
-}
-
-function rpcPayload (method: string, params: any[] = [], id = 1): ProviderRequest {
-  return {
-    method,
-    params,
-    id,
-    jsonrpc: '2.0'
-  }
 }
 
 export default class GasCalculator {
@@ -44,9 +27,9 @@ export default class GasCalculator {
     this.connection = connection
   }
 
-  async _getFeeHistory(numBlocks: number, rewardPercentiles: number[], newestBlock = 'latest'): Promise<Block[]> {
+  private async getFeeHistory(numBlocks: number, rewardPercentiles: number[], newestBlock = 'latest'): Promise<Block[]> {
     const blockCount = intToHex(numBlocks)
-    const payload = rpcPayload('eth_feeHistory', [blockCount, newestBlock, rewardPercentiles])
+    const payload = { method: 'eth_feeHistory', params: [blockCount, newestBlock, rewardPercentiles] }
 
     const feeHistory: FeeHistoryResponse = await this.connection.send(payload)
 
@@ -61,8 +44,40 @@ export default class GasCalculator {
     return feeHistoryBlocks
   }
 
+  private calculateReward (blocks: Block[]) {
+    // these strategies will be tried in descending order until one finds
+    // at least 1 eligible block from which to calculate the reward
+    const rewardCalculationStrategies = [
+      // use recent blocks (last 10) that weren't almost empty or almost full
+      { minRatio: 0.1, maxRatio: 0.9, blockSampleSize: 11 },
+      // include recent blocks that were full
+      { minRatio: 0.1, maxRatio: 1, blockSampleSize: 11 },
+      // use the entire block sample but still limit to blocks that were not almost empty
+      { minRatio: 0.1, maxRatio: 1, blockSampleSize: blocks.length },
+      // use any recent block with transactions
+      { minRatio: 0, maxRatio: Number.MAX_SAFE_INTEGER, blockSampleSize: 11 },
+      // use any block with transactions
+      { minRatio: 0, maxRatio: Number.MAX_SAFE_INTEGER, blockSampleSize: blocks.length }
+    ]
+
+    const eligibleRewardsBlocks = rewardCalculationStrategies.reduce((foundBlocks, strategy, i) => {
+      if (foundBlocks.length === 0) {
+        const blockSample = blocks.slice(blocks.length - Math.min(strategy.blockSampleSize, blocks.length))
+        const eligibleBlocks = blockSample.filter(block => block.gasUsedRatio > strategy.minRatio && block.gasUsedRatio <= strategy.maxRatio)
+
+        if (eligibleBlocks.length > 0) return eligibleBlocks
+      }
+
+      return foundBlocks
+    }, [] as Block[])
+
+    // use the median reward from the block sample or use the fee from the last block as a last resort
+    const lastBlockFee = blocks[blocks.length - 1].rewards[0]
+    return eligibleRewardsBlocks.map(block => block.rewards[0]).sort()[Math.floor(eligibleRewardsBlocks.length / 2)] || lastBlockFee
+  }
+
   async getGasPrices (): Promise<GasPrices> {
-    const gasPrice = await this.connection.send(rpcPayload('eth_gasPrice'))
+    const gasPrice = await this.connection.send({ method: 'eth_gasPrice' })
 
     // in the future we may want to have specific calculators to calculate variations
     // in the gas price or eliminate this structure altogether
@@ -75,22 +90,20 @@ export default class GasCalculator {
   }
   
   async getFeePerGas (): Promise<GasFees> {
-    // fetch the last 10 blocks and the bottom 10% of priority fees paid for each block
-    const blocks = await this._getFeeHistory(10, [10])
+    // fetch the last 30 blocks and the bottom 10% of priority fees paid for each block
+    const blocks = await this.getFeeHistory(30, [10])
     
     // plan for max fee of 2 full blocks, each one increasing the fee by 12.5%
     const nextBlockFee = blocks[blocks.length - 1].baseFee // base fee for next block
     const calculatedFee = Math.ceil(nextBlockFee * 1.125 * 1.125)
 
-    // only consider priority fees from blocks that aren't almost empty or almost full
-    const eligibleRewardsBlocks = blocks.filter(block => block.gasUsedRatio >= 0.1 && block.gasUsedRatio <= 0.9).map(block => block.rewards[0])
-    const medianReward = eligibleRewardsBlocks.sort()[Math.floor(eligibleRewardsBlocks.length / 2)] || 0
+    const medianBlockReward = this.calculateReward(blocks)
 
     return {
       nextBaseFee: intToHex(nextBlockFee),
       maxBaseFeePerGas: intToHex(calculatedFee),
-      maxPriorityFeePerGas: intToHex(medianReward),
-      maxFeePerGas: intToHex(calculatedFee + medianReward)
+      maxPriorityFeePerGas: intToHex(medianBlockReward),
+      maxFeePerGas: intToHex(calculatedFee + medianBlockReward)
     }
   }
 }

--- a/main/transaction/gasCalculator.ts
+++ b/main/transaction/gasCalculator.ts
@@ -60,7 +60,7 @@ export default class GasCalculator {
       { minRatio: 0, maxRatio: Number.MAX_SAFE_INTEGER, blockSampleSize: blocks.length }
     ]
 
-    const eligibleRewardsBlocks = rewardCalculationStrategies.reduce((foundBlocks, strategy, i) => {
+    const eligibleRewardsBlocks = rewardCalculationStrategies.reduce((foundBlocks, strategy) => {
       if (foundBlocks.length === 0) {
         const blockSample = blocks.slice(blocks.length - Math.min(strategy.blockSampleSize, blocks.length))
         const eligibleBlocks = blockSample.filter(block => block.gasUsedRatio > strategy.minRatio && block.gasUsedRatio <= strategy.maxRatio)
@@ -97,7 +97,9 @@ export default class GasCalculator {
     const nextBlockFee = blocks[blocks.length - 1].baseFee // base fee for next block
     const calculatedFee = Math.ceil(nextBlockFee * 1.125 * 1.125)
 
-    const medianBlockReward = this.calculateReward(blocks)
+    // the last block contains only the base fee for the next block but no fee history, so
+    // don't use it in the block reward calculation
+    const medianBlockReward = this.calculateReward(blocks.slice(0, blocks.length - 1))
 
     return {
       nextBaseFee: intToHex(nextBlockFee),

--- a/test/main/chains/index.test.js
+++ b/test/main/chains/index.test.js
@@ -38,7 +38,7 @@ class MockConnection extends EventEmitter {
             baseFeePerGas: [gweiToHex(15), gweiToHex(8), gweiToHex(9), gweiToHex(8), gweiToHex(7)],
             gasUsedRatio: [0.11, 0.8, 0.2, 0.5],
             reward: [
-              [gweiToHex(1), gweiToHex(1), gweiToHex(1), gweiToHex(1),]
+              [gweiToHex(1)], [gweiToHex(1)], [gweiToHex(1)], [gweiToHex(1)]
             ]
           })
         }
@@ -216,7 +216,7 @@ Object.values(mockConnections).forEach(chain => {
     }
 
     const expectedBaseFee = 7e9 * 1.125 * 1.125
-    const expectedPriorityFee = 0
+    const expectedPriorityFee = 1e9
 
     observer = store.observer(() => {
       const gas = store(`main.networksMeta.ethereum.${chain.id}.gas.price`)

--- a/test/main/transaction/gasCalculator.test.js
+++ b/test/main/transaction/gasCalculator.test.js
@@ -168,7 +168,7 @@ describe('#getFeePerGas', () => {
     it('uses any block in the sample if no other blocks are eligible', async () => {
       // index in array represents distance away from current block
       gasUsedRatios[13] = 0.012
-      gasUsedRatios[19] = 1.0239
+      gasUsedRatios[19] = 1.2239
       gasUsedRatios[26] = 1.122
       gasUsedRatios[28] = 0.073
 

--- a/test/main/transaction/gasCalculator.test.js
+++ b/test/main/transaction/gasCalculator.test.js
@@ -54,17 +54,19 @@ describe('#getGasPrices', () => {
 })
 
 describe('#getFeePerGas', () => {
-  let baseFeeHistory = [ '0x8', '0x8', '0x8', '0x8', '0x8', '0x8', '0x8', '0x8', '0x8', '0x8', '0xb6' ]
-  let gasUsedRatios = [ 0.12024061496050893 ]
-  let blockRewards = [ [ '0x3b9aca00' ] ]
+  let gasUsedRatios, blockRewards
 
   beforeEach(() => {
+    // default to all blocks being ineligible for priority fee calculation
+    gasUsedRatios = Array(31).fill(0)
+    blockRewards = Array(31).fill(['0x0'])
+
     requestHandlers = {
       eth_feeHistory: (params) => {
         const numBlocks = parseInt(params[0] || '0x', 16)
 
         return {
-          baseFeePerGas: baseFeeHistory.slice(-numBlocks),
+          baseFeePerGas: Array(numBlocks).fill('0x8').concat(['0xb6']),
           gasUsedRatio: gasUsedRatios,
           oldestBlock: '0x89502f',
           reward: blockRewards
@@ -80,52 +82,116 @@ describe('#getFeePerGas', () => {
   
     expect(fees.maxBaseFeePerGas).toBe('0xe7')
   })
-  
-  it('calculates the priority fee for the next block based on normal blocks', async () => {
-    // all blocks with gas ratios between 0.1 and 0.9 will be considered for calculating the median priority fee
-    gasUsedRatios = [ 0.12024061496050893, 0.17942918604838942, 0.23114498292513627, 0.1801134637893198 ]
-    blockRewards = [ [ '0xee6b2800' ], [ '0x3b9aca00' ], [ '0x77359400' ], [ '0x3b9aca00' ] ]
-  
-    const gas = new GasCalculator(testConnection)
-  
-    const fees = await gas.getFeePerGas()
-  
-    expect(fees.maxPriorityFeePerGas).toBe('0x77359400')
-  })
-  
-  it('excludes full blocks from the priority fee calculation', async () => {
-    // all full blocks (gas ratios above 0.9) will be excluded from calculating the median priority fee
-    gasUsedRatios = [ 0.91024061496050893, 0.17942918604838942, 0.23114498292513627, 1, 0.1801134637893198 ]
-    blockRewards = [ [ '0xee6b2800' ], [ '0x3b9aca00' ], [ '0x77359400' ], [ '0x77359400' ], [ '0x3b9aca00' ] ]
-  
-    const gas = new GasCalculator(testConnection)
-  
-    const fees = await gas.getFeePerGas()
-  
-    expect(fees.maxPriorityFeePerGas).toBe('0x3b9aca00')
-  })
-  
-  it('excludes "empty" blocks from the priority fee calculation', async () => {
-    // all empty blocks (gas ratios below 0.9) will be excluded from calculating the median priority fee
-    gasUsedRatios = [ 0.01024061496050893, 0.17942918604838942, 0.23114498292513627, 0.0801134637893198, 0.1801134637893198 ]
-    blockRewards = [ [ '0xee6b2800' ], [ '0x3b9aca00' ], [ '0x77359400' ], [ '0x77359400' ], [ '0x3b9aca00' ] ]
-  
-    const gas = new GasCalculator(testConnection)
-  
-    const fees = await gas.getFeePerGas()
-  
-    expect(fees.maxPriorityFeePerGas).toBe('0x3b9aca00')
-  })
-  
-  it('uses a default priority fee of zero gwei when no eligible blocks are available', async () => {
-    gasUsedRatios = [ 0.01024061496050893, 0.07942918604838942, 1.23114498292513627, 0.0801134637893198, 1.1801134637893198 ]
-    blockRewards = [ [ '0xee6b2800' ], [ '0x3b9aca00' ], [ '0x77359400' ], [ '0x77359400' ], [ '0x3b9aca00' ] ]
-  
-    const gas = new GasCalculator(testConnection)
-  
-    const fees = await gas.getFeePerGas()
+
+  describe('calculating priority fee', () => {
+    it('calculates the priority fee for the next block based on normal blocks', async () => {
+      // all blocks with gas ratios between 0.1 and 0.9 will be considered for calculating the median priority fee
+      gasUsedRatios = updateEndOfArray(gasUsedRatios, [ 0.12024061496050893, 0.17942918604838942, 0.23114498292513627, 0.1801134637893198 ])
+      blockRewards = updateEndOfArray(blockRewards, [ [ '0xee6b2800' ], [ '0x3b9aca00' ], [ '0x77359400' ], [ '0x3b9aca00' ] ])
     
-    expect(fees.maxBaseFeePerGas).toBe('0xe7')
-    expect(fees.maxPriorityFeePerGas).toBe('0x0')
+      const gas = new GasCalculator(testConnection)
+    
+      const fees = await gas.getFeePerGas()
+    
+      expect(fees.maxPriorityFeePerGas).toBe('0x77359400')
+    })
+    
+    it('excludes full blocks from the priority fee calculation', async () => {
+      // all full blocks (gas ratios above 0.9) will be excluded from calculating the median priority fee
+      gasUsedRatios = updateEndOfArray(gasUsedRatios, [ 0.91024061496050893, 0.17942918604838942, 0.23114498292513627, 1, 0.1801134637893198 ])
+      blockRewards = updateEndOfArray(blockRewards, [ [ '0xee6b2800' ], [ '0x3b9aca00' ], [ '0x77359400' ], [ '0x77359400' ], [ '0x3b9aca00' ] ])
+    
+      const gas = new GasCalculator(testConnection)
+    
+      const fees = await gas.getFeePerGas()
+    
+      expect(fees.maxPriorityFeePerGas).toBe('0x3b9aca00')
+    })
+    
+    it('excludes "empty" blocks from the priority fee calculation', async () => {
+      // all empty blocks (gas ratios below 0.1) will be excluded from calculating the median priority fee
+      gasUsedRatios = updateEndOfArray(gasUsedRatios, [ 0.01024061496050893, 0.17942918604838942, 0.23114498292513627, 0.0801134637893198, 0.1801134637893198 ])
+      blockRewards = updateEndOfArray(blockRewards, [ [ '0xee6b2800' ], [ '0x3b9aca00' ], [ '0x77359400' ], [ '0x77359400' ], [ '0x3b9aca00' ] ])
+    
+      const gas = new GasCalculator(testConnection)
+    
+      const fees = await gas.getFeePerGas()
+    
+      expect(fees.maxPriorityFeePerGas).toBe('0x3b9aca00')
+    })
+    
+    it('considers full blocks if no partial blocks are eligible', async () => {
+      // full blocks (gas ratios above 0.9) will be considered only if no blocks with a ratio between 0.1 and 0.9 are available
+      gasUsedRatios = updateEndOfArray(gasUsedRatios, [ 0.99024061496050893, 0.07942918604838942, 0.03114498292513627, 1, 0.9801134637893198 ])
+      blockRewards = updateEndOfArray(blockRewards, [ [ '0xee6b2800' ], [ '0x3b9aca01' ], [ '0x3b9aca00' ], [ '0x77359400' ], [ '0x3b9aca00' ] ])
+    
+      const gas = new GasCalculator(testConnection)
+    
+      const fees = await gas.getFeePerGas()
+    
+      expect(fees.maxPriorityFeePerGas).toBe('0x77359400')
+    })
+
+    it('considers blocks from the entire sample if none of the last 10 blocks are eligible', async () => {
+      gasUsedRatios[3] = 0.12
+      gasUsedRatios[12] = 0.99
+      gasUsedRatios[15] = 0.02 // this block should be ignored as the ratio is too low
+      gasUsedRatios[19] = 0.73
+
+      blockRewards[3] = [ '0xee6b2800' ]
+      blockRewards[12] = [ '0x3b9aca00' ]
+      blockRewards[15] = [ '0x77359400' ] // this block should be ignored as the ratio is too low
+      blockRewards[19] = [ '0x9a359400' ]
+
+      const gas = new GasCalculator(testConnection)
+    
+      const fees = await gas.getFeePerGas()
+    
+      expect(fees.maxPriorityFeePerGas).toBe('0x9a359400')
+    })
+
+    it('uses any recent blocks if no blocks in the sample have the qualifying gas ratios', async () => {
+      gasUsedRatios = updateEndOfArray(gasUsedRatios, [ 1.09024061496050893, 0.07942918604838942, 0.03114498292513627, 1.1, 0.0801134637893198 ])
+      blockRewards = updateEndOfArray(blockRewards, [ [ '0xee6b2800' ], [ '0x3b9aca01' ], [ '0x3b9aca00' ], [ '0x77359400' ], [ '0x3b9aca00' ] ])
+    
+      const gas = new GasCalculator(testConnection)
+    
+      const fees = await gas.getFeePerGas()
+    
+      expect(fees.maxPriorityFeePerGas).toBe('0x3b9aca01')
+    })
+
+    it('uses any block in the sample if no other blocks are eligible', async () => {
+      gasUsedRatios[2] = 0.012
+      gasUsedRatios[4] = 1.0239
+      gasUsedRatios[11] = 1.122
+      gasUsedRatios[17] = 0.073
+
+      blockRewards[2] = [ '0xee6b2800' ]
+      blockRewards[4] = [ '0x3b9aca00' ]
+      blockRewards[11] = [ '0x77359400' ]
+      blockRewards[17] = [ '0x9a359400' ]
+
+      const gas = new GasCalculator(testConnection)
+    
+      const fees = await gas.getFeePerGas()
+    
+      expect(fees.maxPriorityFeePerGas).toBe('0x9a359400')
+    })
+    
+    it('uses the priority fee from the latest block when no eligible blocks are available', async () => {
+      const gas = new GasCalculator(testConnection)
+    
+      const fees = await gas.getFeePerGas()
+      
+      expect(fees.maxBaseFeePerGas).toBe('0xe7')
+      expect(fees.maxPriorityFeePerGas).toBe('0x0')
+    })
   })
 })
+
+// helper functions
+function updateEndOfArray (arr, replacementValues) {
+  const target = arr.slice(0, arr.length - replacementValues.length)
+  return target.concat(replacementValues)
+}

--- a/test/main/transaction/gasCalculator.test.js
+++ b/test/main/transaction/gasCalculator.test.js
@@ -54,22 +54,25 @@ describe('#getGasPrices', () => {
 })
 
 describe('#getFeePerGas', () => {
+  const nextBlockBaseFee = '0xb6'
+
   let gasUsedRatios, blockRewards
 
   beforeEach(() => {
     // default to all blocks being ineligible for priority fee calculation
-    gasUsedRatios = Array(31).fill(0)
-    blockRewards = Array(31).fill(['0x0'])
+    gasUsedRatios = []
+    blockRewards = []
 
     requestHandlers = {
       eth_feeHistory: (params) => {
         const numBlocks = parseInt(params[0] || '0x', 16)
 
         return {
-          baseFeePerGas: Array(numBlocks).fill('0x8').concat(['0xb6']),
-          gasUsedRatio: gasUsedRatios,
+          // base fees include the requested number of blocks plus the next block
+          baseFeePerGas: Array(numBlocks).fill('0x8').concat([nextBlockBaseFee]),
+          gasUsedRatio: fillEmptySlots(gasUsedRatios, numBlocks, 0).reverse(),
           oldestBlock: '0x89502f',
-          reward: blockRewards
+          reward: fillEmptySlots(blockRewards, numBlocks, ['0x0']).reverse()
         }
       }
     }
@@ -77,113 +80,115 @@ describe('#getFeePerGas', () => {
 
   it('calculates the base fee for the next couple blocks', async () => {
     const gas = new GasCalculator(testConnection)
-  
+
     const fees = await gas.getFeePerGas()
-  
+
     expect(fees.maxBaseFeePerGas).toBe('0xe7')
   })
 
   describe('calculating priority fee', () => {
     it('calculates the priority fee for the next block based on normal blocks', async () => {
       // all blocks with gas ratios between 0.1 and 0.9 will be considered for calculating the median priority fee
-      gasUsedRatios = updateEndOfArray(gasUsedRatios, [ 0.12024061496050893, 0.17942918604838942, 0.23114498292513627, 0.1801134637893198 ])
-      blockRewards = updateEndOfArray(blockRewards, [ [ '0xee6b2800' ], [ '0x3b9aca00' ], [ '0x77359400' ], [ '0x3b9aca00' ] ])
-    
+      gasUsedRatios = [ 0.12024061496050893, 0.17942918604838942, 0.23114498292513627, 0.1801134637893198 ]
+      blockRewards = [ [ '0xee6b2800' ], [ '0x3b9aca00' ], [ '0x77359400' ], [ '0x3b9aca00' ] ]
+
       const gas = new GasCalculator(testConnection)
-    
+
       const fees = await gas.getFeePerGas()
-    
+
       expect(fees.maxPriorityFeePerGas).toBe('0x77359400')
     })
     
     it('excludes full blocks from the priority fee calculation', async () => {
       // all full blocks (gas ratios above 0.9) will be excluded from calculating the median priority fee
-      gasUsedRatios = updateEndOfArray(gasUsedRatios, [ 0.91024061496050893, 0.17942918604838942, 0.23114498292513627, 1, 0.1801134637893198 ])
-      blockRewards = updateEndOfArray(blockRewards, [ [ '0xee6b2800' ], [ '0x3b9aca00' ], [ '0x77359400' ], [ '0x77359400' ], [ '0x3b9aca00' ] ])
-    
+      gasUsedRatios = [ 0.91024061496050893, 0.17942918604838942, 0.23114498292513627, 1, 0.1801134637893198 ]
+      blockRewards = [ [ '0xee6b2800' ], [ '0x3b9aca00' ], [ '0x77359400' ], [ '0x77359400' ], [ '0x3b9aca00' ] ]
+
       const gas = new GasCalculator(testConnection)
-    
+
       const fees = await gas.getFeePerGas()
-    
+
       expect(fees.maxPriorityFeePerGas).toBe('0x3b9aca00')
     })
     
     it('excludes "empty" blocks from the priority fee calculation', async () => {
       // all empty blocks (gas ratios below 0.1) will be excluded from calculating the median priority fee
-      gasUsedRatios = updateEndOfArray(gasUsedRatios, [ 0.01024061496050893, 0.17942918604838942, 0.23114498292513627, 0.0801134637893198, 0.1801134637893198 ])
-      blockRewards = updateEndOfArray(blockRewards, [ [ '0xee6b2800' ], [ '0x3b9aca00' ], [ '0x77359400' ], [ '0x77359400' ], [ '0x3b9aca00' ] ])
-    
+      gasUsedRatios = [ 0.01024061496050893, 0.17942918604838942, 0.23114498292513627, 0.0801134637893198, 0.1801134637893198 ]
+      blockRewards = [ [ '0xee6b2800' ], [ '0x3b9aca00' ], [ '0x77359400' ], [ '0x77359400' ], [ '0x3b9aca00' ] ]
+
       const gas = new GasCalculator(testConnection)
-    
+
       const fees = await gas.getFeePerGas()
-    
+
       expect(fees.maxPriorityFeePerGas).toBe('0x3b9aca00')
     })
     
     it('considers full blocks if no partial blocks are eligible', async () => {
       // full blocks (gas ratios above 0.9) will be considered only if no blocks with a ratio between 0.1 and 0.9 are available
-      gasUsedRatios = updateEndOfArray(gasUsedRatios, [ 0.99024061496050893, 0.07942918604838942, 0.03114498292513627, 1, 0.9801134637893198 ])
-      blockRewards = updateEndOfArray(blockRewards, [ [ '0xee6b2800' ], [ '0x3b9aca01' ], [ '0x3b9aca00' ], [ '0x77359400' ], [ '0x3b9aca00' ] ])
-    
+      gasUsedRatios = [ 0.99024061496050893, 0.07942918604838942, 0.03114498292513627, 1, 0.9801134637893198 ]
+      blockRewards = [ [ '0xee6b2800' ], [ '0x3b9aca01' ], [ '0x3b9aca00' ], [ '0x77359400' ], [ '0x3b9aca00' ] ]
+
       const gas = new GasCalculator(testConnection)
-    
+
       const fees = await gas.getFeePerGas()
-    
+
       expect(fees.maxPriorityFeePerGas).toBe('0x77359400')
     })
 
     it('considers blocks from the entire sample if none of the last 10 blocks are eligible', async () => {
-      gasUsedRatios[3] = 0.12
-      gasUsedRatios[12] = 0.99
-      gasUsedRatios[15] = 0.02 // this block should be ignored as the ratio is too low
-      gasUsedRatios[19] = 0.73
+      // index in array represents distance away from current block
+      gasUsedRatios[11] = 0.12
+      gasUsedRatios[15] = 0.99
+      gasUsedRatios[18] = 0.02 // this block should be ignored as the ratio is too low
+      gasUsedRatios[27] = 0.73
 
-      blockRewards[3] = [ '0xee6b2800' ]
-      blockRewards[12] = [ '0x3b9aca00' ]
-      blockRewards[15] = [ '0x77359400' ] // this block should be ignored as the ratio is too low
-      blockRewards[19] = [ '0x9a359400' ]
+      blockRewards[11] = [ '0xee6b2800' ]
+      blockRewards[15] = [ '0x3b9aca00' ]
+      blockRewards[18] = [ '0x77359400' ] // this block should be ignored as the ratio is too low
+      blockRewards[27] = [ '0x9a359400' ]
 
       const gas = new GasCalculator(testConnection)
-    
+
       const fees = await gas.getFeePerGas()
-    
+
       expect(fees.maxPriorityFeePerGas).toBe('0x9a359400')
     })
 
     it('uses any recent blocks if no blocks in the sample have the qualifying gas ratios', async () => {
-      gasUsedRatios = updateEndOfArray(gasUsedRatios, [ 1.09024061496050893, 0.07942918604838942, 0.03114498292513627, 1.1, 0.0801134637893198 ])
-      blockRewards = updateEndOfArray(blockRewards, [ [ '0xee6b2800' ], [ '0x3b9aca01' ], [ '0x3b9aca00' ], [ '0x77359400' ], [ '0x3b9aca00' ] ])
-    
+      gasUsedRatios = [ 1.09024061496050893, 0.07942918604838942, 0.03114498292513627, 1.1, 0.0801134637893198 ]
+      blockRewards = [ [ '0xee6b2800' ], [ '0x3b9aca01' ], [ '0x3b9aca00' ], [ '0x77359400' ], [ '0x3b9aca00' ] ]
+
       const gas = new GasCalculator(testConnection)
-    
+
       const fees = await gas.getFeePerGas()
-    
+
       expect(fees.maxPriorityFeePerGas).toBe('0x3b9aca01')
     })
 
     it('uses any block in the sample if no other blocks are eligible', async () => {
-      gasUsedRatios[2] = 0.012
-      gasUsedRatios[4] = 1.0239
-      gasUsedRatios[11] = 1.122
-      gasUsedRatios[17] = 0.073
+      // index in array represents distance away from current block
+      gasUsedRatios[13] = 0.012
+      gasUsedRatios[19] = 1.0239
+      gasUsedRatios[26] = 1.122
+      gasUsedRatios[28] = 0.073
 
-      blockRewards[2] = [ '0xee6b2800' ]
-      blockRewards[4] = [ '0x3b9aca00' ]
-      blockRewards[11] = [ '0x77359400' ]
-      blockRewards[17] = [ '0x9a359400' ]
+      blockRewards[13] = [ '0xee6b2800' ]
+      blockRewards[19] = [ '0x3b9aca00' ]
+      blockRewards[26] = [ '0x77359400' ]
+      blockRewards[28] = [ '0x9a359400' ]
 
       const gas = new GasCalculator(testConnection)
-    
+
       const fees = await gas.getFeePerGas()
-    
+
       expect(fees.maxPriorityFeePerGas).toBe('0x9a359400')
     })
     
     it('uses the priority fee from the latest block when no eligible blocks are available', async () => {
       const gas = new GasCalculator(testConnection)
-    
+
       const fees = await gas.getFeePerGas()
-      
+
       expect(fees.maxBaseFeePerGas).toBe('0xe7')
       expect(fees.maxPriorityFeePerGas).toBe('0x0')
     })
@@ -191,7 +196,14 @@ describe('#getFeePerGas', () => {
 })
 
 // helper functions
-function updateEndOfArray (arr, replacementValues) {
-  const target = arr.slice(0, arr.length - replacementValues.length)
-  return target.concat(replacementValues)
+function fillEmptySlots (arr, targetLength, value) {
+  const target = arr.slice()
+  let i = 0
+
+  while (i < targetLength) {
+    target[i] = target[i] || value
+    i += 1
+  }
+
+  return target
 }


### PR DESCRIPTION
Makes the calculation of the expected next block's priority fee -- based on the results of a call to eth_feeHistory -- more resilient. The strategies used to determine the blocks for the calculation will now be the following, tried in order until one yields any eligible blocks:

1. any of the last 10 blocks that have a gas used ratio above 10% and below or equal to 90% (the current strategy)
2. any of the last 10 blocks that have a gas used ratio above 10% and below or equal to 105% (now considering full blocks)
3. any blocks from the entire sample that have a gas used ratio above 10% and below or equal to 105%
4. any of the last 10 blocks with any transactions
5. any blocks from the entire sample with any transactions
6. the priority fee from the last block (most likely zero)