### PR TITLE
feat: implement urbit id as hot phrase signer

### DIFF
--- a/dash/App/Add/AddUrbitID/index.js
+++ b/dash/App/Add/AddUrbitID/index.js
@@ -1,0 +1,193 @@
+import React from 'react'
+import Restore from 'react-restore'
+import ob from 'urbit-ob'
+import log from 'electron-log'
+
+
+import Signer from '../../Signer'
+
+import link from '../../../../resources/link'
+import svg from '../../../../resources/svg'
+
+class AddUrbitID extends React.Component {
+  constructor (...args) {
+    super(...args)
+    this.state = {
+      index: 0,
+      adding: false,
+      ship: '',
+      ticket: '',
+      status: '',
+      error: false
+    }
+    this.forms = [React.createRef(), React.createRef()]
+  }
+
+  onChange (key, e) {
+    e.preventDefault()
+    const update = {}
+    const value = (e.target.value || '')
+    update[key] = value
+    this.setState(update)
+  }
+
+  onBlur (key, e) {
+    e.preventDefault()
+    const update = {}
+    update[key] = this.state[key] || ''
+    this.setState(update)
+  }
+
+  onFocus (key, e) {
+    e.preventDefault()
+    if (this.state[key] === '') {
+      const update = {}
+      update[key] = ''
+      this.setState(update)
+    }
+  }
+
+  next () {
+    this.setState({ index: ++this.state.index })
+    this.focusActive()
+  }
+
+  async create () {
+    this.setState({ index: ++this.state.index })
+
+    const ship = this.state.ship.trim()
+    const ticket = this.state.ticket.trim();
+
+    let point
+    try {
+      point = ob.patp2dec(ship)
+    } catch {
+      return this.setState({
+        status: `${ship} is not a valid @p`,
+        error: true
+      })
+    }
+
+    try {
+      ob.patq2dec(ticket)
+    } catch {
+      return this.setState({
+        status: `${ticket} is not a valid @q`,
+        error: true,
+      })
+    }
+
+    log.info('Deriving Ownership Wallet...')
+    this.setState({ status: 'Deriving...' })
+    link.rpc('createFromMasterTicket', point, ticket, (error, signer) => {
+      if (error) {
+        log.error('Error deriving Ownership Wallet', error)
+        this.setState({
+          status: `Unable to derive Ownership Wallet due to mismatched ship or ticket.`,
+          error: true
+        })
+      } else {
+        this.setState({ status: 'Successful', error: false, createdSignerId: signer.id })
+      }
+    })
+  }
+
+  restart () {
+    this.setState({ index: 0, adding: false, ship: '', ticket: '', success: false })
+    setTimeout(() => {
+      this.setState({ status: '', error: false })
+    }, 500)
+    this.focusActive()
+  }
+
+  keyPress (e) {
+    if (e.key === 'Enter') {
+      e.preventDefault()
+      const formInput = this.forms[this.state.index]
+      if (formInput) formInput.current.blur()
+      if (this.state.index === 1) return this.create()
+      this.next()
+    }
+  }
+
+  adding () {
+    this.setState({ adding: true })
+    this.focusActive()
+  }
+
+  focusActive () {
+    setTimeout(() => {
+      const formInput = this.forms[this.state.index]
+      if (formInput) formInput.current.focus()
+    }, 500)
+  }
+
+  render () {
+    let itemClass = 'addAccountItem addAccountItemSmart addAccountItemAdding'
+
+    let signer
+
+    if (this.state.createdSignerId) {
+      signer = this.store('main.signers', this.state.createdSignerId)
+    }
+
+    return (
+      <div className={itemClass} style={{ transitionDelay: (0.64 * this.props.index / 4) + 's' }}>
+        <div className='addAccountItemBar addAccountItemHot' />
+        <div className='addAccountItemWrap'>
+          <div className='addAccountItemTop'>
+            <div className='addAccountItemTopType'>
+              <div className='addAccountItemIcon'>
+                <div className='addAccountItemIconType addAccountItemIconHot'>{svg.wallet(18)}</div>
+                <div className='addAccountItemIconHex addAccountItemIconHexHot' />
+              </div>
+              <div className='addAccountItemTopTitle'>Urbit ID</div>
+            </div>
+            <div className='addAccountItemClose' onMouseDown={() => this.props.close()}>{'DONE'}</div>
+            <div className='addAccountItemSummary'>Urbit ID is a decentralized addressing and public key infrastructure designed for Urbit OS. Learn more at urbit.org</div>
+          </div>
+          <div className='addAccountItemOption'>
+            <div
+              className='addAccountItemOptionIntro' onMouseDown={() => {
+                this.adding()
+                setTimeout(() => this.store.notify('hotAccountWarning'), 800)
+              }}
+            >
+              Add Urbit ID
+            </div>
+            <div className='addAccountItemOptionSetup' style={{ transform: `translateX(-${100 * this.state.index}%)` }}>
+              <div className='addAccountItemOptionSetupFrames'>
+                <div className='addAccountItemOptionSetupFrame'>
+                  <div className='addAccountItemOptionTitle'>Ship Name</div>
+                  <div className='addAccountItemOptionInputPhrase'>
+                    <input type='text' tabIndex='-1' value={this.state.ship} ref={this.forms[0]} onChange={e => this.onChange('ship', e)} onFocus={e => this.onFocus('ship', e)} onBlur={e => this.onBlur('ship', e)} onKeyPress={e => this.keyPress(e)} placeholder="~sampel-palnet" />
+                  </div>
+                  <div className='addAccountItemOptionSubmit' onMouseDown={() => this.next()}>Next</div>
+                </div>
+                <div className='addAccountItemOptionSetupFrame'>
+                  <div className='addAccountItemOptionTitle'>Master Ticket</div>
+                  <div className='addAccountItemOptionInputPhrase addAccountItemOptionInputPassword'>
+                    <textarea type='text' tabIndex='-1' value={this.state.ticket} ref={this.forms[1]} onChange={e => this.onChange('ticket', e)} onFocus={e => this.onFocus('ticket', e)} onBlur={e => this.onBlur('ticket', e)} onKeyPress={e => this.keyPress(e)} />
+                  </div>
+                  <div className='addAccountItemOptionSubmit' onMouseDown={() => this.create()}>Create</div>
+                </div>
+                <div className='addAccountItemOptionSetupFrame'>
+                  {signer ? <Signer key={signer.id} {...signer} inSetup={true} />
+                  : (
+                    <>
+                      <div className='addAccountItemOptionTitle'>{this.state.status}</div>
+                      {this.state.error ? <div className='addAccountItemOptionSubmit' onMouseDown={() => this.restart()}>try again</div> : null}
+                    </>
+                  )}
+                </div>
+              </div>
+            </div>
+          </div>
+          <div className='addAccountItemFooter' />
+        </div>
+      </div>
+    )
+  }
+}
+
+export default Restore.connect(AddUrbitID)

--- a/dash/App/index.js
+++ b/dash/App/index.js
@@ -10,6 +10,7 @@ import AddPhrase from './Add/AddPhrase'
 import AddRing from './Add/AddRing'
 import AddKeystore from './Add/AddKeystore'
 import AddAddress from './Add/AddAddress'
+import AddUrbitID from './Add/AddUrbitID'
 
 class AddAccounts extends React.Component {
   constructor (...args) {
@@ -21,7 +22,7 @@ class AddAccounts extends React.Component {
   renderAddNonsigning () {
     return (
       <div className='addAccounts cardShow'>
-       <AddAddress close={this.props.close} />          
+       <AddAddress close={this.props.close} />
       </div>
     )
   }
@@ -43,6 +44,13 @@ class AddAccounts extends React.Component {
     return (
       <div className='addAccounts cardShow'>
        <AddPhrase close={this.props.close} />
+      </div>
+    )
+  }
+  renderAddUrbitID () {
+    return (
+      <div className='addAccounts cardShow'>
+       <AddUrbitID close={this.props.close} />
       </div>
     )
   }
@@ -92,6 +100,7 @@ class AddAccounts extends React.Component {
         <div className='accountTypeSelect' onClick={() => this.setState({ view: 'ledger' })}>Ledger Device</div>
         <div className='accountTypeSelect' onClick={() => this.setState({ view: 'trezor' })}>Trezor Device</div>
         <div className='accountTypeSelect' onClick={() => this.setState({ view: 'aragon' })}>Aragon DAO</div>
+        <div className='accountTypeSelect' onClick={() => this.setState({ view: 'urbit-id' })}>Urbit ID</div>
         {/* <div className='accountTypeSelect' onClick={() => this.setState({ view: 'gnosis' })}>Gnosis Safe</div> */}
         <div className='accountTypeSelect' onClick={() => this.setState({ view: 'seed' })}>Seed Phrase</div>
         <div className='accountTypeSelect' onClick={() => this.setState({ view: 'keyring' })}>Private Key</div>
@@ -106,6 +115,8 @@ class AddAccounts extends React.Component {
       return this.renderDefault()
     } else if (view === 'aragon')  {
       return this.renderAddAragon()
+    } else if (view === 'urbit-id') {
+      return this.renderAddUrbitID();
     // } else if (view === 'gnosis')  {
     //   return this.renderAddGnosis()
     } else if (view === 'ledger')  {
@@ -140,7 +151,7 @@ class Dash extends React.Component {
       const hardwareSigners = Object.keys(this.store('main.signers')).map(s => {
         const signer = this.store('main.signers', s)
         if (
-          signer.type === 'ledger' || 
+          signer.type === 'ledger' ||
           signer.type === 'trezor' ||
           signer.type === 'lattice'
         ) {
@@ -152,7 +163,7 @@ class Dash extends React.Component {
       const hotSigners = Object.keys(this.store('main.signers')).map(s => {
         const signer = this.store('main.signers', s)
         if (
-          signer.type === 'seed' || 
+          signer.type === 'seed' ||
           signer.type === 'ring'
         ) {
           return signer
@@ -160,12 +171,12 @@ class Dash extends React.Component {
           return false
         }
       }).filter(s => s)
-      
+
       return (
       <div className='dash'>
         {this.state.showAddAccounts ? <AddAccounts close={() => this.setState({ showAddAccounts: false })} /> : null}
         <div className='newAccount' onClick={() => this.setState({ showAddAccounts: !this.state.showAddAccounts })}>
-          <div className='newAccountIcon'>{'+'}</div> 
+          <div className='newAccountIcon'>{'+'}</div>
           Add New Account
         </div>
         <div className='signers'>

--- a/main/rpc/index.js
+++ b/main/rpc/index.js
@@ -2,6 +2,7 @@ const { ipcMain, dialog } = require('electron')
 const fs = require('fs')
 const utils = require('web3-utils')
 const crypto = require('crypto')
+const { generateOwnershipWallet } = require('urbit-key-generation')
 
 const accounts = require('../accounts').default
 const signers = require('../signers').default
@@ -88,13 +89,13 @@ const rpc = {
     }
 
     store.updateLattice(deviceId, {
-      deviceId, 
+      deviceId,
       baseUrl: 'https://signing.gridpl.us',
       endpointMode: 'default',
       paired: true,
       deviceName: (deviceName || 'GridPlus').substring(0, 14),
       tag: randomLetters(6),
-      privKey: crypto.randomBytes(32).toString('hex')  
+      privKey: crypto.randomBytes(32).toString('hex')
     })
 
     cb(null, { id: 'lattice-' + deviceId })
@@ -181,6 +182,11 @@ const rpc = {
   },
   createFromPhrase (phrase, password, cb) {
     signers.createFromPhrase(phrase, password, cb)
+  },
+  createFromMasterTicket (ship, ticket, cb) {
+    generateOwnershipWallet({ ship, ticket })
+      .then(wallet => this.createFromPhrase(wallet.seed, ticket, cb))
+      .catch((err) => cb(err, null))
   },
   locateKeystore (cb) {
     dialog.showOpenDialog({ properties: ['openFile'] }).then(file => {

--- a/package-lock.json
+++ b/package-lock.json
@@ -54,6 +54,8 @@
         "react-transition-group": "4.4.2",
         "semver": "7.3.6",
         "trezor-connect": "8.2.9-extended",
+        "urbit-key-generation": "^0.20.1",
+        "urbit-ob": "^5.0.1",
         "uuid": "8.3.2",
         "web3-utils": "1.7.3",
         "ws": "8.5.0",
@@ -7883,6 +7885,11 @@
         "node": ">= 6"
       }
     },
+    "node_modules/argon2-wasm": {
+      "version": "0.9.0",
+      "resolved": "https://registry.npmjs.org/argon2-wasm/-/argon2-wasm-0.9.0.tgz",
+      "integrity": "sha512-bt5xqrDt5FnA1gdLLouOwi2NN1h9BeML8DmKth7CCYhygoXUEDeIxEMB++q+CUPQ8U5gju065Z0MjI+hVSXX7A=="
+    },
     "node_modules/argparse": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
@@ -9075,6 +9082,22 @@
       "integrity": "sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==",
       "dependencies": {
         "file-uri-to-path": "1.0.0"
+      }
+    },
+    "node_modules/bip32": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/bip32/-/bip32-1.0.4.tgz",
+      "integrity": "sha512-8T21eLWylZETolyqCPgia+MNp+kY37zFr7PTFDTPObHeNi9JlfG4qGIh8WzerIJidtwoK+NsWq2I5i66YfHoIw==",
+      "dependencies": {
+        "bs58check": "^2.1.1",
+        "create-hash": "^1.2.0",
+        "create-hmac": "^1.1.7",
+        "tiny-secp256k1": "^1.0.0",
+        "typeforce": "^1.11.5",
+        "wif": "^2.0.6"
+      },
+      "engines": {
+        "node": ">=6.0.0"
       }
     },
     "node_modules/bip39": {
@@ -12347,6 +12370,19 @@
       "resolved": "https://registry.npmjs.org/dotenv-expand/-/dotenv-expand-4.2.0.tgz",
       "integrity": "sha512-pHWVt6L/YkqbBCMb1hG6e7oO0WdMhlapDIibl+BZ9PncVE3i+G77uvNr8GUxW2ItSituOK8QOYC9oOJjwWD94A==",
       "dev": true
+    },
+    "node_modules/drbg.js": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/drbg.js/-/drbg.js-1.0.1.tgz",
+      "integrity": "sha512-F4wZ06PvqxYLFEZKkFxTDcns9oFNk34hvmJSEwdzsxVQ8YI5YaxtACgQatkYgv2VI2CFkUd2Y+xosPQnHv809g==",
+      "dependencies": {
+        "browserify-aes": "^1.0.6",
+        "create-hash": "^1.1.2",
+        "create-hmac": "^1.1.4"
+      },
+      "engines": {
+        "node": ">=0.10"
+      }
     },
     "node_modules/duplexer2": {
       "version": "0.1.4",
@@ -31319,6 +31355,11 @@
       "dev": true,
       "peer": true
     },
+    "node_modules/lodash.chunk": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/lodash.chunk/-/lodash.chunk-4.2.0.tgz",
+      "integrity": "sha512-ZzydJKfUHJwHa+hF5X66zLFCBrWn5GeF28OHEr4WVWtNDXlQ/IjWKPBiikqKo2ne0+v6JgCgJ0GzJp8k8bHC7w=="
+    },
     "node_modules/lodash.clone": {
       "version": "4.5.0",
       "resolved": "https://registry.npmjs.org/lodash.clone/-/lodash.clone-4.5.0.tgz",
@@ -41995,6 +42036,14 @@
         "node": ">= 10.0.0"
       }
     },
+    "node_modules/unorm": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/unorm/-/unorm-1.6.0.tgz",
+      "integrity": "sha512-b2/KCUlYZUeA7JFUuRJZPUtr4gZvBh7tavtv4fvk4+KV9pfGiR6CQAQAWl49ZpR3ts2dk4FYkP7EIgDJoiOLDA==",
+      "engines": {
+        "node": ">= 0.4.0"
+      }
+    },
     "node_modules/unpipe": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
@@ -42214,6 +42263,103 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/urbit-key-generation": {
+      "version": "0.20.1",
+      "resolved": "https://registry.npmjs.org/urbit-key-generation/-/urbit-key-generation-0.20.1.tgz",
+      "integrity": "sha512-/IYaH149EJ45TxY4gL081d72mmcyngJwMOGCudi9QR3KY+VRtYoLFIX9QQa630/5dsbJKisylZScaFpnfEs0nQ==",
+      "dependencies": {
+        "argon2-wasm": "^0.9.0",
+        "bip32": "^1.0.2",
+        "bip39": "^2.5.0",
+        "js-sha256": "^0.9.0",
+        "jsbn": "^1.1.0",
+        "keccak": "^1.4.0",
+        "secp256k1": "^3.5.2",
+        "tweetnacl": "^1.0.0",
+        "urbit-ob": "4.1.4"
+      }
+    },
+    "node_modules/urbit-key-generation/node_modules/bip39": {
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/bip39/-/bip39-2.6.0.tgz",
+      "integrity": "sha512-RrnQRG2EgEoqO24ea+Q/fftuPUZLmrEM3qNhhGsA3PbaXaCW791LTzPuVyx/VprXQcTbPJ3K3UeTna8ZnVl2sg==",
+      "dependencies": {
+        "create-hash": "^1.1.0",
+        "pbkdf2": "^3.0.9",
+        "randombytes": "^2.0.1",
+        "safe-buffer": "^5.0.1",
+        "unorm": "^1.3.3"
+      }
+    },
+    "node_modules/urbit-key-generation/node_modules/bn.js": {
+      "version": "4.12.0",
+      "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.0.tgz",
+      "integrity": "sha512-c98Bf3tPniI+scsdk237ku1Dc3ujXQTSgyiPUDEOe7tRkhrqridvh8klBv0HCEso1OLOYcHuCv/cS6DNxKH+ZA=="
+    },
+    "node_modules/urbit-key-generation/node_modules/jsbn": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-1.1.0.tgz",
+      "integrity": "sha512-4bYVV3aAMtDTTu4+xsDYa6sy9GyJ69/amsu9sYF2zqjiEoZA5xJi3BrfX3uY+/IekIu7MwdObdbDWpoZdBv3/A=="
+    },
+    "node_modules/urbit-key-generation/node_modules/keccak": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/keccak/-/keccak-1.4.0.tgz",
+      "integrity": "sha512-eZVaCpblK5formjPjeTBik7TAg+pqnDrMHIffSvi9Lh7PQgM1+hSzakUeZFCk9DVVG0dacZJuaz2ntwlzZUIBw==",
+      "hasInstallScript": true,
+      "dependencies": {
+        "bindings": "^1.2.1",
+        "inherits": "^2.0.3",
+        "nan": "^2.2.1",
+        "safe-buffer": "^5.1.0"
+      },
+      "engines": {
+        "node": ">=4.0.0"
+      }
+    },
+    "node_modules/urbit-key-generation/node_modules/secp256k1": {
+      "version": "3.8.0",
+      "resolved": "https://registry.npmjs.org/secp256k1/-/secp256k1-3.8.0.tgz",
+      "integrity": "sha512-k5ke5avRZbtl9Tqx/SA7CbY3NF6Ro+Sj9cZxezFzuBlLDmyqPiL8hJJ+EmzD8Ig4LUDByHJ3/iPOVoRixs/hmw==",
+      "hasInstallScript": true,
+      "dependencies": {
+        "bindings": "^1.5.0",
+        "bip66": "^1.1.5",
+        "bn.js": "^4.11.8",
+        "create-hash": "^1.2.0",
+        "drbg.js": "^1.0.1",
+        "elliptic": "^6.5.2",
+        "nan": "^2.14.0",
+        "safe-buffer": "^5.1.2"
+      },
+      "engines": {
+        "node": ">=4.0.0"
+      }
+    },
+    "node_modules/urbit-key-generation/node_modules/urbit-ob": {
+      "version": "4.1.4",
+      "resolved": "https://registry.npmjs.org/urbit-ob/-/urbit-ob-4.1.4.tgz",
+      "integrity": "sha512-9sa7L+NUvlhP+okIMNyu8Bxn5VNDGo6AGVvCgOpEghqrEayk2uEoPeDV+ghGsCt1bA+4fjFMa7RG5ybZjgrtWQ==",
+      "dependencies": {
+        "bn.js": "^4.11.8",
+        "lodash.chunk": "^4.2.0",
+        "lodash.isequal": "^4.5.0"
+      }
+    },
+    "node_modules/urbit-ob": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/urbit-ob/-/urbit-ob-5.0.1.tgz",
+      "integrity": "sha512-qGNAwu87XNkW3g8ah4fUwmh2EKXtsdhEbyEiE5qX4Op17rhLH3HSkvu8g9z+MhqX51Uz9sf8ktvqJj/IRwETIQ==",
+      "dependencies": {
+        "bn.js": "^4.11.8",
+        "lodash.chunk": "^4.2.0",
+        "lodash.isequal": "^4.5.0"
+      }
+    },
+    "node_modules/urbit-ob/node_modules/bn.js": {
+      "version": "4.12.0",
+      "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.0.tgz",
+      "integrity": "sha512-c98Bf3tPniI+scsdk237ku1Dc3ujXQTSgyiPUDEOe7tRkhrqridvh8klBv0HCEso1OLOYcHuCv/cS6DNxKH+ZA=="
     },
     "node_modules/uri-js": {
       "version": "4.4.1",
@@ -50845,6 +50991,11 @@
         }
       }
     },
+    "argon2-wasm": {
+      "version": "0.9.0",
+      "resolved": "https://registry.npmjs.org/argon2-wasm/-/argon2-wasm-0.9.0.tgz",
+      "integrity": "sha512-bt5xqrDt5FnA1gdLLouOwi2NN1h9BeML8DmKth7CCYhygoXUEDeIxEMB++q+CUPQ8U5gju065Z0MjI+hVSXX7A=="
+    },
     "argparse": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
@@ -51803,6 +51954,19 @@
       "integrity": "sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==",
       "requires": {
         "file-uri-to-path": "1.0.0"
+      }
+    },
+    "bip32": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/bip32/-/bip32-1.0.4.tgz",
+      "integrity": "sha512-8T21eLWylZETolyqCPgia+MNp+kY37zFr7PTFDTPObHeNi9JlfG4qGIh8WzerIJidtwoK+NsWq2I5i66YfHoIw==",
+      "requires": {
+        "bs58check": "^2.1.1",
+        "create-hash": "^1.2.0",
+        "create-hmac": "^1.1.7",
+        "tiny-secp256k1": "^1.0.0",
+        "typeforce": "^1.11.5",
+        "wif": "^2.0.6"
       }
     },
     "bip39": {
@@ -54394,6 +54558,16 @@
       "resolved": "https://registry.npmjs.org/dotenv-expand/-/dotenv-expand-4.2.0.tgz",
       "integrity": "sha512-pHWVt6L/YkqbBCMb1hG6e7oO0WdMhlapDIibl+BZ9PncVE3i+G77uvNr8GUxW2ItSituOK8QOYC9oOJjwWD94A==",
       "dev": true
+    },
+    "drbg.js": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/drbg.js/-/drbg.js-1.0.1.tgz",
+      "integrity": "sha512-F4wZ06PvqxYLFEZKkFxTDcns9oFNk34hvmJSEwdzsxVQ8YI5YaxtACgQatkYgv2VI2CFkUd2Y+xosPQnHv809g==",
+      "requires": {
+        "browserify-aes": "^1.0.6",
+        "create-hash": "^1.1.2",
+        "create-hmac": "^1.1.4"
+      }
     },
     "duplexer2": {
       "version": "0.1.4",
@@ -69323,6 +69497,11 @@
       "dev": true,
       "peer": true
     },
+    "lodash.chunk": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/lodash.chunk/-/lodash.chunk-4.2.0.tgz",
+      "integrity": "sha512-ZzydJKfUHJwHa+hF5X66zLFCBrWn5GeF28OHEr4WVWtNDXlQ/IjWKPBiikqKo2ne0+v6JgCgJ0GzJp8k8bHC7w=="
+    },
     "lodash.clone": {
       "version": "4.5.0",
       "resolved": "https://registry.npmjs.org/lodash.clone/-/lodash.clone-4.5.0.tgz",
@@ -77703,6 +77882,11 @@
       "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.0.tgz",
       "integrity": "sha512-hAZsKq7Yy11Zu1DE0OzWjw7nnLZmJZYTDZZyEFHZdUhV8FkH5MCfoU1XMaxXovpyW5nq5scPqq0ZDP9Zyl04oQ=="
     },
+    "unorm": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/unorm/-/unorm-1.6.0.tgz",
+      "integrity": "sha512-b2/KCUlYZUeA7JFUuRJZPUtr4gZvBh7tavtv4fvk4+KV9pfGiR6CQAQAWl49ZpR3ts2dk4FYkP7EIgDJoiOLDA=="
+    },
     "unpipe": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
@@ -77860,6 +78044,99 @@
           "requires": {
             "has-flag": "^4.0.0"
           }
+        }
+      }
+    },
+    "urbit-key-generation": {
+      "version": "0.20.1",
+      "resolved": "https://registry.npmjs.org/urbit-key-generation/-/urbit-key-generation-0.20.1.tgz",
+      "integrity": "sha512-/IYaH149EJ45TxY4gL081d72mmcyngJwMOGCudi9QR3KY+VRtYoLFIX9QQa630/5dsbJKisylZScaFpnfEs0nQ==",
+      "requires": {
+        "argon2-wasm": "^0.9.0",
+        "bip32": "^1.0.2",
+        "bip39": "^2.5.0",
+        "js-sha256": "^0.9.0",
+        "jsbn": "^1.1.0",
+        "keccak": "^1.4.0",
+        "secp256k1": "^3.5.2",
+        "tweetnacl": "^1.0.0",
+        "urbit-ob": "4.1.4"
+      },
+      "dependencies": {
+        "bip39": {
+          "version": "2.6.0",
+          "resolved": "https://registry.npmjs.org/bip39/-/bip39-2.6.0.tgz",
+          "integrity": "sha512-RrnQRG2EgEoqO24ea+Q/fftuPUZLmrEM3qNhhGsA3PbaXaCW791LTzPuVyx/VprXQcTbPJ3K3UeTna8ZnVl2sg==",
+          "requires": {
+            "create-hash": "^1.1.0",
+            "pbkdf2": "^3.0.9",
+            "randombytes": "^2.0.1",
+            "safe-buffer": "^5.0.1",
+            "unorm": "^1.3.3"
+          }
+        },
+        "bn.js": {
+          "version": "4.12.0",
+          "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.0.tgz",
+          "integrity": "sha512-c98Bf3tPniI+scsdk237ku1Dc3ujXQTSgyiPUDEOe7tRkhrqridvh8klBv0HCEso1OLOYcHuCv/cS6DNxKH+ZA=="
+        },
+        "jsbn": {
+          "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-1.1.0.tgz",
+          "integrity": "sha512-4bYVV3aAMtDTTu4+xsDYa6sy9GyJ69/amsu9sYF2zqjiEoZA5xJi3BrfX3uY+/IekIu7MwdObdbDWpoZdBv3/A=="
+        },
+        "keccak": {
+          "version": "1.4.0",
+          "resolved": "https://registry.npmjs.org/keccak/-/keccak-1.4.0.tgz",
+          "integrity": "sha512-eZVaCpblK5formjPjeTBik7TAg+pqnDrMHIffSvi9Lh7PQgM1+hSzakUeZFCk9DVVG0dacZJuaz2ntwlzZUIBw==",
+          "requires": {
+            "bindings": "^1.2.1",
+            "inherits": "^2.0.3",
+            "nan": "^2.2.1",
+            "safe-buffer": "^5.1.0"
+          }
+        },
+        "secp256k1": {
+          "version": "3.8.0",
+          "resolved": "https://registry.npmjs.org/secp256k1/-/secp256k1-3.8.0.tgz",
+          "integrity": "sha512-k5ke5avRZbtl9Tqx/SA7CbY3NF6Ro+Sj9cZxezFzuBlLDmyqPiL8hJJ+EmzD8Ig4LUDByHJ3/iPOVoRixs/hmw==",
+          "requires": {
+            "bindings": "^1.5.0",
+            "bip66": "^1.1.5",
+            "bn.js": "^4.11.8",
+            "create-hash": "^1.2.0",
+            "drbg.js": "^1.0.1",
+            "elliptic": "^6.5.2",
+            "nan": "^2.14.0",
+            "safe-buffer": "^5.1.2"
+          }
+        },
+        "urbit-ob": {
+          "version": "4.1.4",
+          "resolved": "https://registry.npmjs.org/urbit-ob/-/urbit-ob-4.1.4.tgz",
+          "integrity": "sha512-9sa7L+NUvlhP+okIMNyu8Bxn5VNDGo6AGVvCgOpEghqrEayk2uEoPeDV+ghGsCt1bA+4fjFMa7RG5ybZjgrtWQ==",
+          "requires": {
+            "bn.js": "^4.11.8",
+            "lodash.chunk": "^4.2.0",
+            "lodash.isequal": "^4.5.0"
+          }
+        }
+      }
+    },
+    "urbit-ob": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/urbit-ob/-/urbit-ob-5.0.1.tgz",
+      "integrity": "sha512-qGNAwu87XNkW3g8ah4fUwmh2EKXtsdhEbyEiE5qX4Op17rhLH3HSkvu8g9z+MhqX51Uz9sf8ktvqJj/IRwETIQ==",
+      "requires": {
+        "bn.js": "^4.11.8",
+        "lodash.chunk": "^4.2.0",
+        "lodash.isequal": "^4.5.0"
+      },
+      "dependencies": {
+        "bn.js": {
+          "version": "4.12.0",
+          "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.0.tgz",
+          "integrity": "sha512-c98Bf3tPniI+scsdk237ku1Dc3ujXQTSgyiPUDEOe7tRkhrqridvh8klBv0HCEso1OLOYcHuCv/cS6DNxKH+ZA=="
         }
       }
     },

--- a/package.json
+++ b/package.json
@@ -103,6 +103,8 @@
     "react-transition-group": "4.4.2",
     "semver": "7.3.6",
     "trezor-connect": "8.2.9-extended",
+    "urbit-key-generation": "^0.20.1",
+    "urbit-ob": "^5.0.1",
     "uuid": "8.3.2",
     "web3-utils": "1.7.3",
     "ws": "8.5.0",


### PR DESCRIPTION
This is an implementation of Urbit ID for frame, which allows Urbit users to connect to the wider Ethereum ecosystem with their Ownership Address.

Please offer any feedback, I tried to match the existing style as much as possible. Note that the master ticket derivation must occur in the rpc because of the wasm execution within `urbit-key-generation`.

(the initial boilerplate for `AddUrbitID` was `AddPhrase`)

my editor also removed some trailing spaces—hopefully it's ok to include those changes for now. in the future i'd recommend an eslint config and git hooks to prevent malformatted code in commits.