### PR TITLE
Fix Watch-only error: Type not being passed in correctly

### DIFF
--- a/main/rpc/index.js
+++ b/main/rpc/index.js
@@ -169,7 +169,7 @@ const rpc = {
   },
   createFromAddress (address, cb) {
     if (!utils.isAddress(address)) return cb(new Error('Invalid Address'))
-    accounts.add(address, { type: 'Address' })
+    accounts.add(address, '', { type: 'Address' })
     cb()
   },
   createAccount (address, name, options, cb) {

--- a/main/rpc/index.js
+++ b/main/rpc/index.js
@@ -169,7 +169,7 @@ const rpc = {
   },
   createFromAddress (address, cb) {
     if (!utils.isAddress(address)) return cb(new Error('Invalid Address'))
-    accounts.add(address, '', { type: 'Address' })
+    accounts.add(address, 'Watch Only Account', { type: 'Address' })
     cb()
   },
   createAccount (address, name, options, cb) {


### PR DESCRIPTION
pass in a value for name so that the options parameter is correctly used