### PR TITLE
Add shortcut to the wallet page to quickly open the address in the explorer

### DIFF
--- a/app/App/Panel/Main/Account/Requests/TransactionRequest/index.js
+++ b/app/App/Panel/Main/Account/Requests/TransactionRequest/index.js
@@ -318,9 +318,9 @@ class TransactionRequest extends React.Component {
                               onMouseDown={() => {
                                 if (req && req.tx && req.tx.hash) {
                                   if (this.store('main.mute.explorerWarning')) {
-                                    link.send('tray:openExplorer', req.tx.hash, this.chain)
+                                    link.send('tray:openExplorer', 'transaction', req.tx.hash, this.chain)
                                   } else {
-                                    this.store.notify('openExplorer', { hash: req.tx.hash, chain: this.chain })
+                                    this.store.notify('openExplorer', { type: 'transaction', hash_or_address: req.tx.hash, chain: this.chain })
                                   }
                                 }
                               }}

--- a/app/App/Panel/Main/Account/Settings/index.js
+++ b/app/App/Panel/Main/Account/Settings/index.js
@@ -76,6 +76,18 @@ class Settings extends React.Component {
               }}>Remove This Account</div>
             </>
           )}
+          <br />
+          <div className='moduleButton' onMouseDown={() => {
+            const chain = this.store('main.currentNetwork')
+
+            if (this.store('main.mute.explorerWarning')) {
+              link.send('tray:openExplorer', 'address', account.address, chain)
+            } else {
+              this.store.notify('openExplorer', { type: 'address', hash_or_address: account.address, chain })
+            }
+          }}>
+            Open in Explorer
+          </div>
         </div>
       </div>
     )

--- a/app/App/Panel/Notify/index.js
+++ b/app/App/Panel/Notify/index.js
@@ -469,17 +469,29 @@ class Notify extends React.Component {
     )
   }
 
-  openExplorer ({ hash, chain }) {
+  openExplorer ({ type, chain, hash_or_address }) {
+	let notifyBody = <div></div>
+	if (type === 'transaction') {
+		notifyBody = <div className='notifyBody'>
+			<div className='notifyBodyLine'>Frame will open a block explorer in your browser for transaction:</div>
+			<div className='notifyBodyElement'>{hash_or_address}</div>
+		</div>
+	} else {
+		notifyBody = <div className='notifyBody'>
+			<div className='notifyBodyLine'>Frame will open a block explorer in your browser for address:</div>
+			<div className='notifyBodyElement'>{hash_or_address}</div>
+		</div> 
+	}
+
     return (
       <div className='notifyBoxWrap' onMouseDown={e => e.stopPropagation()}>
         <div className='notifyBox'>
           <div className='notifyTitle'>
             Open Block Explorer
           </div>
-          <div className='notifyBody'>
-            <div className='notifyBodyLine'>Frame will open a block explorer in your browser for transaction:</div>
-            <div className='notifyBodyHash'>{hash}</div>
-          </div>
+
+          { notifyBody }
+
           <div className='notifyInput'>
             <div
               className='notifyInputOption notifyInputDeny' onMouseDown={() => {
@@ -490,7 +502,7 @@ class Notify extends React.Component {
             </div>
             <div
               className='notifyInputOption notifyInputProceed' onMouseDown={() => {
-                link.send('tray:openExplorer', hash, chain)
+                link.send('tray:openExplorer', type, hash_or_address, chain)
                 this.store.notify()
               }}
             >
@@ -508,7 +520,7 @@ class Notify extends React.Component {
               ) : null}
             </div>
             <div className='notifyCheckText'>
-              {'Don\'t show this warning again'}
+				Don't show this warning again
             </div>
           </div>
         </div>

--- a/app/App/Panel/Notify/style/index.styl
+++ b/app/App/Panel/Notify/style/index.styl
@@ -168,7 +168,7 @@
           text-decoration underline
           cursor pointer
 
-        .notifyBodyHash
+        .notifyBodyElement
           font-size 14px
           font-family FiraCode, monospace
           background var(--ghostB)

--- a/main/index.js
+++ b/main/index.js
@@ -197,12 +197,13 @@ ipcMain.on('tray:openExternal', (e, url) => {
   if (validHost) shell.openExternal(url)
 })
 
-ipcMain.on('tray:openExplorer', (e, hash, chain) => {
+ipcMain.on('tray:openExplorer', (e, type, hash_or_address, chain) => {
   // remove trailing slashes from the base url
   const explorer = (store('main.networks', chain.type, chain.id, 'explorer') || '').replace(/\/+$/, '')
 
   if (explorer) {
-    shell.openExternal(`${explorer}/tx/${hash}`)
+    const directory = type === 'transaction' ? 'tx' : 'address';
+    shell.openExternal(`${explorer}/${directory}/${hash_or_address}`)
   }
 })
 


### PR DESCRIPTION
Adds a button under "Account Settings" to open the current address in explorer. Also modularizes `tray:openExplorer` to accept both hash and addresses. Maybe block numbers in the future as well.