### PR TITLE
add degraded status, stop block monitor on bad status changes

### DIFF
--- a/app/App/Account/RequestCommand/TxBar/index.js
+++ b/app/App/Account/RequestCommand/TxBar/index.js
@@ -12,7 +12,7 @@ class TxBar extends React.Component {
     else if (req.status === 'sending') position = 2
     else if (req.status === 'verifying') position = 3
     else if (req.status === 'verified') position = 4
-    else if (req.status === 'confirming' || req.status === 'confirmed') {
+    else if (req.status === 'confirming' || req.status === 'confirmed' || req.status === 'sent') {
       position = 4
       progressIconClass += ' txProgressStepIconHidden'
       txBarClass += ' txBarSuccess'

--- a/dash/App/Chains/Chain/Connection/index.js
+++ b/dash/App/Chains/Chain/Connection/index.js
@@ -14,10 +14,14 @@ const ConnectionIndicator = ({ className, connection }) => {
   const isPending = connection.status === 'pending'
   const isSyncing = connection.status === 'syncing'
   const isStandBy = connection.status === 'standby'
+  const isDegraded = connection.status === 'degraded'
+
   let status = 'Bad'
 
   if (isConnected) {
     status = 'Good'
+  } else if (isDegraded) {
+    status = 'Warning'
   } else if (isLoading || isPending || isSyncing || isStandBy) {
     status = 'Pending'
   }

--- a/dash/App/Chains/style/index.styl
+++ b/dash/App/Chains/style/index.styl
@@ -498,6 +498,10 @@
       background var(--pending)
       box-shadow 0px 0px 4px var(--pending)
 
+    .sliceTileIndicatorWarning
+      background var(--warning)
+      box-shadow 0px 0px 4px var(--warning)
+
     .sliceTileIndicatorBad
       background var(--bad)
       box-shadow 0px 0px 4px var(--bad)
@@ -625,6 +629,8 @@
           background var(--bad)
         .connectionOptionStatusIndicatorPending
           background var(--pending)
+        .connectionOptionStatusIndicatorWarning
+          background var(--warning)
 
         .connectionOptionStatusText
           height 20px

--- a/main/accounts/index.ts
+++ b/main/accounts/index.ts
@@ -275,18 +275,28 @@ export class Accounts extends EventEmitter {
     })
   }
 
-  private async txMonitor (account: FrameAccount, id: string, hash: string) {
+  private async txMonitor (account: FrameAccount, requestId: string, hash: string) {
     if (!account) return log.error('txMonitor had no target account')
 
-    const txRequest = this.getTransactionRequest(account, id)
+    const txRequest = this.getTransactionRequest(account, requestId)
     const rawTx = txRequest.data
     txRequest.tx = { hash, confirmations: 0 }
 
     account.update()
 
+    const isChainAvailable = (status: string) => !['disconnected', 'degraded'].includes(status.toLowerCase())
+
+    const setTxSent = () => {
+      txRequest.status = RequestStatus.Sent
+      txRequest.notice = 'Sent'
+      
+      if (txRequest.tx) txRequest.tx.confirmations = 0
+      account.update()
+    }
+
     if (!rawTx.chainId) {
       log.error('txMonitor had no target chain')
-      setTimeout(() => this.accounts[account.address] && this.removeRequest(account, id), 8 * 1000)
+      setTimeout(() => this.accounts[account.address] && this.removeRequest(account, requestId), 8 * 1000)
     } else {
       const targetChain: Chain = {
         type: 'ethereum',
@@ -305,7 +315,7 @@ export class Accounts extends EventEmitter {
 
             let confirmations
             try {
-              confirmations = await this.confirmations(account, id, hash, targetChain)
+              confirmations = await this.confirmations(account, requestId, hash, targetChain)
               txRequest.tx = { ...txRequest.tx, confirmations }
 
               account.update()
@@ -314,24 +324,42 @@ export class Accounts extends EventEmitter {
                 txRequest.status = RequestStatus.Confirmed
                 txRequest.notice = 'Confirmed'
                 account.update()
-                setTimeout(() => this.accounts[account.address] && this.removeRequest(account, id), 8000)
-                clearTimeout(monitorTimer)
+                setTimeout(() => this.accounts[account.address] && this.removeRequest(account, requestId), 8000)
+                clear()
               }
             } catch (e) {
               log.error('error awaiting confirmations', e)
-              clearTimeout(monitorTimer)
-              setTimeout(() => this.accounts[account.address] && this.removeRequest(account, id), 60 * 1000)
+              clear()
+              setTimeout(() => this.accounts[account.address] && this.removeRequest(account, requestId), 60 * 1000)
               return
             }
           }
+
           setTimeout(() => monitor(), 3000)
           const monitorTimer = setInterval(monitor, 15000)
+
+          const statusHandler = (status: string) => {
+            if (!isChainAvailable(status)) {
+              setTxSent()
+              clear()
+            }
+          }
+
+          const { type, id } = targetChain
+
+          provider.on(`status:${type}:${id}`, statusHandler)
+
+          const clear = () => {
+            clearInterval(monitorTimer)
+            provider.off(`status:${type}:${id}`, statusHandler)
+          }
         } else if (newHeadRes.result) {
           const headSub = newHeadRes.result
 
           const removeSubscription = async (requestRemoveTimeout: number) => {
-            setTimeout(() => this.accounts[account.address] && this.removeRequest(account, id), requestRemoveTimeout)
+            setTimeout(() => this.accounts[account.address] && this.removeRequest(account, requestId), requestRemoveTimeout)
             provider.off(`data:${targetChain.type}:${targetChain.id}`, handler)
+            provider.off(`status:${targetChain.type}:${targetChain.id}`, statusHandler)
             this.sendRequest({ method: 'eth_unsubscribe', chainId: targetChainId, params: [headSub] }, (res: RPCResponsePayload) => {
               if (res.error) {
                 log.error('error sending message eth_unsubscribe', res)
@@ -339,12 +367,19 @@ export class Accounts extends EventEmitter {
             })
           }
 
+          const statusHandler = (status: string) => {
+            if (!isChainAvailable(status)) {
+              setTxSent()
+              removeSubscription(60 * 1000)
+            }
+          }
+
           const handler = async (payload: RPCRequestPayload) => {
             if (payload.method === 'eth_subscription' && (payload.params as any).subscription === headSub) {
               // const newHead = payload.params.result
               let confirmations
               try {
-                confirmations = await this.confirmations(account, id, hash, targetChain)
+                confirmations = await this.confirmations(account, requestId, hash, targetChain)
               } catch (e) {
                 log.error(e)
 
@@ -364,12 +399,10 @@ export class Accounts extends EventEmitter {
             }
           }
 
-          provider.on(`data:${targetChain.type}:${targetChain.id}`, handler)
-          // provider.on('data', ({ type, id }, ...args) => {
-          //   if (id === targetChain.id) {
-          //     handler(args)
-          //   }
-          // })
+          const { type, id } = targetChain
+
+          provider.on(`status:${type}:${id}`, statusHandler)
+          provider.on(`data:${type}:${id}`, handler)
         }
       })
     }

--- a/main/accounts/index.ts
+++ b/main/accounts/index.ts
@@ -330,6 +330,7 @@ export class Accounts extends EventEmitter {
             } catch (e) {
               log.error('error awaiting confirmations', e)
               clear()
+              setTxSent()
               setTimeout(() => this.accounts[account.address] && this.removeRequest(account, requestId), 60 * 1000)
               return
             }
@@ -383,6 +384,7 @@ export class Accounts extends EventEmitter {
               } catch (e) {
                 log.error(e)
 
+                setTxSent()
                 return removeSubscription(60 * 1000)
               }
 

--- a/main/accounts/types.ts
+++ b/main/accounts/types.ts
@@ -20,6 +20,7 @@ export enum RequestStatus {
   Verifying = 'verifying',
   Confirming = 'confirming',
   Confirmed = 'confirmed',
+  Sent = 'sent',
   Declined = 'declined',
   Error = 'error',
   Success = 'success'
@@ -28,15 +29,15 @@ export enum RequestStatus {
 type RequestType = 'sign' | 'signTypedData' | 'transaction' | 'access' | 'addChain' | 'switchChain' | 'addToken'
 
 export interface AccountRequest {
-  type: RequestType,
-  origin: string,
-  payload: JSONRPCRequestPayload,
-  handlerId: string,
-  account: string,
-  status?: RequestStatus,
-  mode?: RequestMode,
-  notice?: string,
-  created?: number,
+  type: RequestType
+  origin: string
+  payload: JSONRPCRequestPayload
+  handlerId: string
+  account: string
+  status?: RequestStatus
+  mode?: RequestMode
+  notice?: string
+  created?: number
   res?: (response?: RPCResponsePayload) => void
 }
 

--- a/main/chains/blocks/index.ts
+++ b/main/chains/blocks/index.ts
@@ -71,7 +71,7 @@ class BlockMonitor extends EventEmitter {
       .then(subId => this.subscriptionId = subId)
       .catch(err => {
         // subscriptions are not supported, poll for block changes instead
-        this._clearSubscription()
+        this.clearSubscription()
         
         this.poller = setInterval(this.getLatestBlock, 15 * 1000)
       })
@@ -83,38 +83,38 @@ class BlockMonitor extends EventEmitter {
     this.connection.off('close', this.stop)
 
     if (this.subscriptionId) {
-      this._clearSubscription()
+      this.clearSubscription()
     }
 
     if (this.poller) {
-      this._stopPoller()
+      this.stopPoller()
     }
   }
 
-  _clearSubscription () {
+  private clearSubscription () {
     this.connection.off('message', this.handleMessage)
     this.subscriptionId = ''
   }
 
-  _stopPoller () {
+  private stopPoller () {
     clearInterval(<NodeJS.Timeout>this.poller)
     this.poller = undefined
   }
 
-  getLatestBlock () {
+  private getLatestBlock () {
     this.connection
       .send({ id: 1, jsonrpc: '2.0', method: 'eth_getBlockByNumber', params: ['latest', false] })
       .then(block => this.handleBlock(block))
       .catch(err => this.handleError(`Could not load block for chain ${this.connection.chainId}`, err))
   }
 
-  handleMessage (message: SubscriptionMessage) {
+  private handleMessage (message: SubscriptionMessage) {
     if (message.type === 'eth_subscription' && message.data.subscription === this.subscriptionId) {
       this.handleBlock(message.data.result)
     }
   }
 
-  handleBlock (block: Block) {
+  private handleBlock (block: Block) {
     if (!block) return this.handleError('handleBlock received undefined block')
 
     if (block.number !== this.latestBlock) {
@@ -124,7 +124,7 @@ class BlockMonitor extends EventEmitter {
     }
   }
 
-  handleError (...args: any) {
+  private handleError (...args: any) {
     this.connection.emit('status', 'degraded')
     log.error(...args)
   }

--- a/main/chains/blocks/index.ts
+++ b/main/chains/blocks/index.ts
@@ -4,36 +4,36 @@ import log from 'electron-log'
 import type { BigNumber } from 'bignumber.js'
 
 interface Connection extends EventEmitter {
-  send (payload: JSONRPCRequestPayload): Promise<any>,
+  send (payload: JSONRPCRequestPayload): Promise<any>
   chainId: string
 }
 
 interface SubscriptionMessage {
-  type: 'eth_subscription',
+  type: 'eth_subscription'
   data: {
-    subscription: string,
+    subscription: string
     result: Block
   }
 }
 
 interface Block {
-  number: string,
-  hash: string | null,
-  parentHash: string,
-  nonce: string | null,
-  sha3Uncles: string,
-  logsBloom: string | null,
-  transactionsRoot: string,
-  stateRoot: string,
-  miner: string,
-  difficulty: BigNumber,
-  totalDifficulty: BigNumber,
-  extraData: string,
-  size: number,
-  gasLimit: number,
-  gasUsed: number,
-  timestamp: number,
-  uncles: string[],
+  number: string
+  hash: string | null
+  parentHash: string
+  nonce: string | null
+  sha3Uncles: string
+  logsBloom: string | null
+  transactionsRoot: string
+  stateRoot: string
+  miner: string
+  difficulty: BigNumber
+  totalDifficulty: BigNumber
+  extraData: string
+  size: number
+  gasLimit: number
+  gasUsed: number
+  timestamp: number
+  uncles: string[]
 }
 
 class BlockMonitor extends EventEmitter {
@@ -104,10 +104,8 @@ class BlockMonitor extends EventEmitter {
   getLatestBlock () {
     this.connection
       .send({ id: 1, jsonrpc: '2.0', method: 'eth_getBlockByNumber', params: ['latest', false] })
-      .then(this.handleBlock)
-      .catch(err => {
-        log.error(`Could not load block for chain ${this.connection.chainId}`, err)
-      })
+      .then(block => this.handleBlock(block))
+      .catch(err => this.handleError(`Could not load block for chain ${this.connection.chainId}`, err))
   }
 
   handleMessage (message: SubscriptionMessage) {
@@ -117,11 +115,21 @@ class BlockMonitor extends EventEmitter {
   }
 
   handleBlock (block: Block) {
-    if (!block) return log.error('handleBlock received undefined block')
+    if (parseInt(this.connection.chainId) === 11155111 && Math.random() < 0.5) {
+      return this.handleError('BAD BLOCK')
+    }
+    if (!block) return this.handleError('handleBlock received undefined block')
+
     if (block.number !== this.latestBlock) {
       this.latestBlock = block.number
+      this.connection.emit('status', 'connected')
       this.emit('data', block)
     }
+  }
+
+  handleError (...args: any) {
+    this.connection.emit('status', 'degraded')
+    log.error(...args)
   }
 }
 

--- a/main/chains/blocks/index.ts
+++ b/main/chains/blocks/index.ts
@@ -115,9 +115,6 @@ class BlockMonitor extends EventEmitter {
   }
 
   handleBlock (block: Block) {
-    if (parseInt(this.connection.chainId) === 11155111 && Math.random() < 0.5) {
-      return this.handleError('BAD BLOCK')
-    }
     if (!block) return this.handleError('handleBlock received undefined block')
 
     if (block.number !== this.latestBlock) {

--- a/main/chains/index.d.ts
+++ b/main/chains/index.d.ts
@@ -3,7 +3,7 @@ import { chainsType } from '@ethereumjs/common/dist/types'
 import { EventEmitter } from 'stream'
 
 export interface Chain {
-  id: number,
+  id: number
   type: 'ethereum'
 }
 

--- a/main/chains/index.js
+++ b/main/chains/index.js
@@ -263,7 +263,7 @@ class ChainConnection extends EventEmitter {
               this.primary.status = 'error'
               this.update('secondary')
 
-              //this._updateStatus('secondary', 'error')
+              this._updateStatus('secondary', 'error')
             } else {
               this.secondary.network = !err && response && !response.error ? response.result : ''
               if (this.secondary.network && this.secondary.network !== this.chainId) {
@@ -337,10 +337,6 @@ class ChainConnection extends EventEmitter {
               } else {
                 this.primary.connected = true
                 this.primary.type = ''
-                //this.primary.status = 'connected'
-
-                //this.update('primary')
-                //this.emit('connect')
 
                 this._handleConnection('primary')
               }

--- a/main/provider/index.ts
+++ b/main/provider/index.ts
@@ -91,9 +91,11 @@ export class Provider extends EventEmitter {
       this.connected = true
       this.emit('connect', ...args)
     })
+
     this.connection.on('close', () => { 
       this.connected = false
     })
+
     this.connection.on('data', (chain, ...args) => {
       if ((args[0] || {}).method === 'eth_subscription') {
         this.emit('data:subscription', ...args)
@@ -101,12 +103,20 @@ export class Provider extends EventEmitter {
 
       this.emit(`data:${chain.type}:${chain.id}`, ...args)
     })
+
     this.connection.on('error', (chain, err) => {
       log.error(err)
     })
-    this.connection.on('update', (chain, event) => {
+
+    this.connection.on('update', (chain: Chain, event) => {
+      console.log('CHANI UPDATE', { chain, event })
       if (event.type === 'fees') {
-        return accounts.updatePendingFees(event.chainId)
+        return accounts.updatePendingFees(chain.id)
+      }
+
+      if (event.type === 'status') {
+        console.log('EMITTING', `status:${chain.type}:${chain.id}`)
+        this.emit(`status:${chain.type}:${chain.id}`, event.status)
       }
     })
 

--- a/main/provider/index.ts
+++ b/main/provider/index.ts
@@ -109,13 +109,11 @@ export class Provider extends EventEmitter {
     })
 
     this.connection.on('update', (chain: Chain, event) => {
-      console.log('CHANI UPDATE', { chain, event })
       if (event.type === 'fees') {
         return accounts.updatePendingFees(chain.id)
       }
 
       if (event.type === 'status') {
-        console.log('EMITTING', `status:${chain.type}:${chain.id}`)
         this.emit(`status:${chain.type}:${chain.id}`, event.status)
       }
     })

--- a/resources/base.styl
+++ b/resources/base.styl
@@ -263,6 +263,8 @@ body
   --pendingShade2 rgb(104, 80, 225)
   --pendingOver rgb(240, 240, 255)
 
+  --warning rgb(230, 184, 0)
+
   --foreverwhite rgba(242, 242, 255, 1)
 
   // --moon rgba(242, 168, 59, 1)


### PR DESCRIPTION
- introduces a "degraded" connection status that, for now, is activated if we fail to load a block, and is set back to "connected" once a block is successfully loaded
- adds status events emitted by each connection. right now these are only listened to by the transaction monitor so that we can stop trying to confirm a transaction if we temporarily lost connection. currently it will lose the subscription and keep showing "confirming" forever
- adds additional transaction status "sent" for transactions that were successfully sent to the chain but could not be confirmed