### PR TITLE
System Tray rework

### DIFF
--- a/main/index.ts
+++ b/main/index.ts
@@ -320,30 +320,6 @@ app.on('ready', () => {
 
     if (filePath.startsWith(appOrigin)) cb({ path: filePath }) // eslint-disable-line
   })
-
-  store.observer(() => {
-    if (store('windows.dash.showing')) {
-      windows.showDash()
-    } else {
-      windows.hideDash()
-      windows.focusTray()
-    }
-  })
-  store.observer(() => {
-    if (!store('windows.dawn.showing')) {
-      windows.hideDawn()
-      windows.focusTray()
-    }
-  })
-  store.observer(() => {
-    const altSlash = store('main.shortcuts.altSlash')
-    if (altSlash) {
-      globalShortcut.unregister('Alt+/')
-      globalShortcut.register('Alt+/', () => windows.toggleTray())
-    } else {
-      globalShortcut.unregister('Alt+/')
-    }
-  })
 })
 
 ipcMain.on('tray:action', (e, action, ...args) => {

--- a/main/windows/index.ts
+++ b/main/windows/index.ts
@@ -469,14 +469,19 @@ const init = () => {
       windows.tray.focus()
     }
   })
+  store.observer(() => broadcast('permissions', JSON.stringify(store('permissions'))))
   store.observer(() => {
-    if (store('main.shortcuts.altSlash')) {
+    const displaySummonShortcut = store('main.shortcuts.altSlash')
+    if (displaySummonShortcut) {
       globalShortcut.unregister('Alt+/')
       globalShortcut.register('Alt+/', () => {
         menuClickHandlers[tray.isVisible() ? 'hide' : 'show']()
       })
     } else {
       globalShortcut.unregister('Alt+/')
+    }
+    if (tray?.isReady()) {
+      setContextMenu(tray.isVisible() ? 'hide' : 'show', menuClickHandlers, displaySummonShortcut)
     }
   })
 }
@@ -493,15 +498,6 @@ const broadcast = (channel: string, ...args: string[]) => {
   Object.keys(windows).forEach((id) => send(id, channel, ...args))
   frameManager.broadcast(channel, args)
 }
-
-// Data Change Events
-store.observer(() => broadcast('permissions', JSON.stringify(store('permissions'))))
-store.observer(() => {
-  const displaySummonShortcut = store('main.shortcuts.altSlash')
-  if (tray?.isReady()) {
-    setContextMenu(tray.isVisible() ? 'hide' : 'show', menuClickHandlers, displaySummonShortcut)
-  }
-})
 
 store.api.feed((_state, actions) => {
   actions.forEach((action) => {

--- a/main/windows/index.ts
+++ b/main/windows/index.ts
@@ -179,6 +179,7 @@ export class Tray {
     })
     this.readyHandler = () => {
       initSystemTray(this.toggle)
+      setContextMenu('hide', menuClickHandlers, getDisplaySummonShortcut())
       if (showOnReady) {
         store.trayOpen(true)
       }
@@ -211,7 +212,6 @@ export class Tray {
   }
 
   hide() {
-    // store.toggleDash('hide')
     if (this.recentDisplayEvent || !windows.tray?.isVisible()) {
       return
     }
@@ -221,6 +221,7 @@ export class Tray {
       this.recentDisplayEvent = false
     }, 150)
 
+    store.toggleDash('hide')
     store.trayOpen(false)
     if (store('main.reveal')) {
       detectMouse()

--- a/main/windows/index.ts
+++ b/main/windows/index.ts
@@ -1,13 +1,4 @@
-import {
-  app,
-  BrowserWindow,
-  ipcMain,
-  screen,
-  Tray as ElectronTray,
-  globalShortcut,
-  IpcMainEvent,
-  WebContents
-} from 'electron'
+import { app, BrowserWindow, ipcMain, screen, globalShortcut, IpcMainEvent, WebContents } from 'electron'
 import path from 'path'
 import log from 'electron-log'
 import EventEmitter from 'events'
@@ -16,7 +7,7 @@ import { hexToInt } from '../../resources/utils'
 import store from '../store'
 import FrameManager from './frames'
 import { createWindow } from './window'
-import { createContextMenu } from './systemTray'
+import { closeContextMenu, setContextMenu } from './systemTray'
 
 type Windows = { [key: string]: BrowserWindow }
 
@@ -109,22 +100,18 @@ function initTrayWindow() {
 
   windows.tray.on('show', () => {
     if (process.platform === 'win32') {
-      tray.electronTray.closeContextMenu()
+      closeContextMenu()
     }
     setTimeout(() => {
-      tray.electronTray.setContextMenu(
-        createContextMenu('hide', menuClickHandlers, getDisplaySummonShortcut())
-      )
+      setContextMenu('hide', menuClickHandlers, getDisplaySummonShortcut())
     }, 100)
   })
   windows.tray.on('hide', () => {
     if (process.platform === 'win32') {
-      tray.electronTray.closeContextMenu()
+      closeContextMenu()
     }
     setTimeout(() => {
-      tray.electronTray.setContextMenu(
-        createContextMenu('show', menuClickHandlers, getDisplaySummonShortcut())
-      )
+      setContextMenu('show', menuClickHandlers, getDisplaySummonShortcut())
     }, 100)
   })
 
@@ -168,12 +155,8 @@ export class Tray {
   private gasObserver: Observer
   private ready: boolean
   private readyHandler: () => void
-  public electronTray: ElectronTray
 
   constructor() {
-    this.electronTray = new ElectronTray(
-      path.join(__dirname, process.platform === 'darwin' ? './IconTemplate.png' : './Icon.png')
-    )
     this.ready = false
     this.gasObserver = store.observer(() => {
       let title = ''
@@ -468,10 +451,7 @@ store.observer(() => broadcast('permissions', JSON.stringify(store('permissions'
 store.observer(() => {
   const displaySummonShortcut = store('main.shortcuts.altSlash')
   if (tray?.isReady()) {
-    const contextMenu = tray.isVisible()
-      ? createContextMenu('hide', menuClickHandlers, displaySummonShortcut)
-      : createContextMenu('show', menuClickHandlers, displaySummonShortcut)
-    tray.electronTray.setContextMenu(contextMenu)
+    setContextMenu(tray.isVisible() ? 'hide' : 'show', menuClickHandlers, displaySummonShortcut)
   }
 })
 

--- a/main/windows/index.ts
+++ b/main/windows/index.ts
@@ -45,18 +45,14 @@ const contextMenu = (displaySummonShortcut: boolean = store('main.shortcuts.altS
     click: () => {},
     type: 'separator'
   }
-  const hideMenuItem = {
+  const hideMenuItem: Electron.MenuItemConstructorOptions = {
     label: 'Dismiss',
     click: hideFrame,
-    accelerator: 'Alt+/',
-    registerAccelerator: false,
     toolTip: 'Dismiss Frame'
   }
-  const showMenuItem = {
+  const showMenuItem: Electron.MenuItemConstructorOptions = {
     label: 'Summon',
     click: showFrame,
-    accelerator: 'Alt+/',
-    registerAccelerator: false,
     toolTip: 'Summon Frame'
   }
   const quitMenuItem = {

--- a/main/windows/index.ts
+++ b/main/windows/index.ts
@@ -32,12 +32,25 @@ let dash: Dash
 let dawn: Dawn
 let mouseTimeout: NodeJS.Timeout
 let glide = false
+let dashHiddenByAppHide = false
 
 const enableHMR = isDev && process.env.HMR === 'true'
 
 const menuClickHandlers = {
-  hide: () => tray.hide(),
-  show: () => tray.show()
+  hide: () => {
+    tray.hide()
+    if (dash.isVisible()) {
+      dashHiddenByAppHide = true
+      dash.hide()
+    }
+  },
+  show: () => {
+    tray.show()
+    if (dashHiddenByAppHide) {
+      dashHiddenByAppHide = false
+      dash.show()
+    }
+  }
 }
 const getDisplaySummonShortcut = () => store('main.shortcuts.altSlash')
 
@@ -320,6 +333,10 @@ class Dash {
       }
     }, 10)
   }
+
+  isVisible() {
+    return (windows.dash as BrowserWindow).isVisible()
+  }
 }
 
 class Dawn {
@@ -459,7 +476,7 @@ store.api.feed((_state, actions) => {
 })
 
 export default {
-  toggleTray: () => {
+  toggleTray() {
     tray.toggle()
   },
   showTray() {

--- a/main/windows/index.ts
+++ b/main/windows/index.ts
@@ -496,8 +496,8 @@ const broadcast = (channel: string, ...args: string[]) => {
 // Data Change Events
 store.observer(() => broadcast('permissions', JSON.stringify(store('permissions'))))
 store.observer(() => {
+  const displaySummonShortcut = store('main.shortcuts.altSlash')
   if (tray?.isReady()) {
-    const displaySummonShortcut = store('main.shortcuts.altSlash')
     tray.electronTray.setContextMenu(contextMenu(displaySummonShortcut))
   }
 })

--- a/main/windows/index.ts
+++ b/main/windows/index.ts
@@ -133,15 +133,15 @@ function initTrayWindow() {
 
   windows.tray.on('show', () => {
     if (process.platform === 'win32') {
-      systemTray?.closeContextMenu()
+      systemTray.closeContextMenu()
     }
-    systemTray?.setContextMenu('hide', getDisplaySummonShortcut())
+    systemTray.setContextMenu('hide', getDisplaySummonShortcut())
   })
   windows.tray.on('hide', () => {
     if (process.platform === 'win32') {
-      systemTray?.closeContextMenu()
+      systemTray.closeContextMenu()
     }
-    systemTray?.setContextMenu('show', getDisplaySummonShortcut())
+    systemTray.setContextMenu('show', getDisplaySummonShortcut())
   })
 
   setTimeout(() => {

--- a/main/windows/systemTray.ts
+++ b/main/windows/systemTray.ts
@@ -2,11 +2,9 @@ import { app, Menu, Tray as ElectronTray } from 'electron'
 import path from 'path'
 import store from '../store'
 
-const electronTray = new ElectronTray(
-  path.join(__dirname, process.platform === 'darwin' ? './IconTemplate.png' : './Icon.png')
-)
-let recentElectronTrayClick = false
+let electronTray: ElectronTray
 let recentElectronTrayClickTimeout: NodeJS.Timeout
+let recentElectronTrayClick = false
 
 export const setContextMenu = (
   type: string,
@@ -39,16 +37,19 @@ export const setContextMenu = (
   }
 
   const menu = Menu.buildFromTemplate([actionMenuItem, separatorMenuItem, quitMenuItem])
-  electronTray.setContextMenu(menu)
+  electronTray?.setContextMenu(menu)
 }
 
-export const closeContextMenu = () => electronTray.closeContextMenu()
+export const closeContextMenu = () => electronTray?.closeContextMenu()
 
-export const setTitle = (title: string) => electronTray.setTitle(title)
+export const setTitle = (title: string) => electronTray?.setTitle(title)
 
 export const hasRecentClick = () => recentElectronTrayClick
 
 export const init = (appWindowToggle: () => void) => {
+  electronTray = new ElectronTray(
+    path.join(__dirname, process.platform === 'darwin' ? './IconTemplate.png' : './Icon.png')
+  )
   electronTray.on('click', () => {
     recentElectronTrayClick = true
     clearTimeout(recentElectronTrayClickTimeout as NodeJS.Timeout)

--- a/main/windows/systemTray.ts
+++ b/main/windows/systemTray.ts
@@ -1,0 +1,36 @@
+import { app, Menu } from 'electron'
+import store from '../store'
+
+export const createContextMenu = (
+  type: string,
+  clickHandlers: { show: () => void; hide: () => void },
+  displaySummonShortcut: boolean = store('main.shortcuts.altSlash')
+) => {
+  const separatorMenuItem = {
+    label: 'Frame',
+    click: () => {},
+    type: 'separator'
+  }
+  const menuItemLabelMap = {
+    hide: 'Dismiss',
+    show: 'Summon'
+  }
+  const label = menuItemLabelMap[type as keyof typeof menuItemLabelMap]
+  const actionType = type === 'show' ? 'hide' : 'show'
+  const actionMenuItem: Electron.MenuItemConstructorOptions = {
+    label,
+    click: clickHandlers[actionType as keyof typeof clickHandlers],
+    toolTip: `${label} Frame`
+  }
+  const quitMenuItem = {
+    label: 'Quit',
+    click: () => app.quit()
+  }
+
+  if (displaySummonShortcut) {
+    actionMenuItem.accelerator = 'Alt+/'
+    actionMenuItem.registerAccelerator = false
+  }
+
+  return Menu.buildFromTemplate([actionMenuItem, separatorMenuItem, quitMenuItem])
+}

--- a/main/windows/systemTray.ts
+++ b/main/windows/systemTray.ts
@@ -16,10 +16,9 @@ export const createContextMenu = (
     show: 'Summon'
   }
   const label = menuItemLabelMap[type as keyof typeof menuItemLabelMap]
-  const actionType = type === 'show' ? 'hide' : 'show'
   const actionMenuItem: Electron.MenuItemConstructorOptions = {
     label,
-    click: clickHandlers[actionType as keyof typeof clickHandlers],
+    click: clickHandlers[type as keyof typeof clickHandlers],
     toolTip: `${label} Frame`
   }
   const quitMenuItem = {

--- a/main/windows/systemTray.ts
+++ b/main/windows/systemTray.ts
@@ -36,9 +36,7 @@ export const setContextMenu = (
 
   const menu = Menu.buildFromTemplate([actionMenuItem, separatorMenuItem, quitMenuItem])
 
-  setTimeout(() => {
-    electronTray?.setContextMenu(menu)
-  }, 200)
+  setTimeout(() => electronTray?.setContextMenu(menu), process.platform === 'darwin' ? 0 : 200)
 }
 
 export const closeContextMenu = () => electronTray?.closeContextMenu()

--- a/main/windows/systemTray.ts
+++ b/main/windows/systemTray.ts
@@ -1,7 +1,12 @@
-import { app, Menu } from 'electron'
+import { app, Menu, Tray as ElectronTray } from 'electron'
+import path from 'path'
 import store from '../store'
 
-export const createContextMenu = (
+const electronTray = new ElectronTray(
+  path.join(__dirname, process.platform === 'darwin' ? './IconTemplate.png' : './Icon.png')
+)
+
+export const setContextMenu = (
   type: string,
   clickHandlers: { show: () => void; hide: () => void },
   displaySummonShortcut: boolean = store('main.shortcuts.altSlash')
@@ -31,5 +36,8 @@ export const createContextMenu = (
     actionMenuItem.registerAccelerator = false
   }
 
-  return Menu.buildFromTemplate([actionMenuItem, separatorMenuItem, quitMenuItem])
+  const menu = Menu.buildFromTemplate([actionMenuItem, separatorMenuItem, quitMenuItem])
+  electronTray.setContextMenu(menu)
 }
+
+export const closeContextMenu = () => electronTray.closeContextMenu()

--- a/main/windows/systemTray.ts
+++ b/main/windows/systemTray.ts
@@ -5,6 +5,8 @@ import store from '../store'
 const electronTray = new ElectronTray(
   path.join(__dirname, process.platform === 'darwin' ? './IconTemplate.png' : './Icon.png')
 )
+let recentElectronTrayClick = false
+let recentElectronTrayClickTimeout: NodeJS.Timeout
 
 export const setContextMenu = (
   type: string,
@@ -41,3 +43,20 @@ export const setContextMenu = (
 }
 
 export const closeContextMenu = () => electronTray.closeContextMenu()
+
+export const setTitle = (title: string) => electronTray.setTitle(title)
+
+export const hasRecentClick = () => recentElectronTrayClick
+
+export const init = (appWindowToggle: () => void) => {
+  electronTray.on('click', () => {
+    recentElectronTrayClick = true
+    clearTimeout(recentElectronTrayClickTimeout as NodeJS.Timeout)
+    recentElectronTrayClickTimeout = setTimeout(() => {
+      recentElectronTrayClick = false
+    }, 50)
+    if (process.platform === 'win32') {
+      appWindowToggle()
+    }
+  })
+}

--- a/main/windows/systemTray.ts
+++ b/main/windows/systemTray.ts
@@ -3,8 +3,6 @@ import path from 'path'
 import store from '../store'
 
 let electronTray: ElectronTray
-let recentElectronTrayClickTimeout: NodeJS.Timeout
-let recentElectronTrayClick = false
 
 export const setContextMenu = (
   type: string,
@@ -23,7 +21,7 @@ export const setContextMenu = (
   const label = menuItemLabelMap[type as keyof typeof menuItemLabelMap]
   const actionMenuItem: Electron.MenuItemConstructorOptions = {
     label,
-    click: clickHandlers[type as keyof typeof clickHandlers],
+    click: () => clickHandlers[type as keyof typeof clickHandlers](),
     toolTip: `${label} Frame`
   }
   const quitMenuItem = {
@@ -37,25 +35,21 @@ export const setContextMenu = (
   }
 
   const menu = Menu.buildFromTemplate([actionMenuItem, separatorMenuItem, quitMenuItem])
-  electronTray?.setContextMenu(menu)
+
+  setTimeout(() => {
+    electronTray?.setContextMenu(menu)
+  }, 200)
 }
 
 export const closeContextMenu = () => electronTray?.closeContextMenu()
 
 export const setTitle = (title: string) => electronTray?.setTitle(title)
 
-export const hasRecentClick = () => recentElectronTrayClick
-
 export const init = (appWindowToggle: () => void) => {
   electronTray = new ElectronTray(
     path.join(__dirname, process.platform === 'darwin' ? './IconTemplate.png' : './Icon.png')
   )
   electronTray.on('click', () => {
-    recentElectronTrayClick = true
-    clearTimeout(recentElectronTrayClickTimeout as NodeJS.Timeout)
-    recentElectronTrayClickTimeout = setTimeout(() => {
-      recentElectronTrayClick = false
-    }, 50)
     if (process.platform === 'win32') {
       appWindowToggle()
     }

--- a/main/windows/systemTray.ts
+++ b/main/windows/systemTray.ts
@@ -20,6 +20,7 @@ export class SystemTray {
   }
 
   init() {
+    // Electron Tray can only be instantiated when the app is ready
     this.electronTray = new ElectronTray(path.join(__dirname, isMacOS ? './IconTemplate.png' : './Icon.png'))
     this.electronTray.on('click', this.clickHandlers.click)
   }


### PR DESCRIPTION
* updating the context menus on change of the summon shortcut setting
* extracted system tray handling to new module
* hiding dash when the user requests hide of tray
* showing dash with summon of tray when dash was previously hidden by user action

TODO:

- [x] Manual merge of #1276 
- [x] Manual testing: Mac
- [x] Manual testing: Windoze
- [x] Manual testing: Linux