### PR TITLE
Electronegativity update

### DIFF
--- a/.github/workflows/compile-and-test.yml
+++ b/.github/workflows/compile-and-test.yml
@@ -18,8 +18,6 @@ jobs:
           node-version: 16.15.0
       - name: Electronegativity
         uses: doyensec/electronegativity-action@v2.0
-        with:
-          exclude-checks: 'LimitNavigationGlobalCheck'
       - name: Upload sarif
         uses: github/codeql-action/upload-sarif@v2
         with:

--- a/package.json
+++ b/package.json
@@ -160,7 +160,7 @@
     "stylus": "0.59.0",
     "ts-jest": "29.0.3",
     "typescript": "4.9.3",
-    "wait-on": "^6.0.1"
+    "wait-on": "6.0.1"
   },
   "overrides": {
     "node-hid": "2.1.2"

--- a/resources/utils/displayValue.ts
+++ b/resources/utils/displayValue.ts
@@ -33,6 +33,13 @@ function isLargeNumber(bn: BigNumber) {
 }
 
 function getDisplay(bn: BigNumber, type: string, decimals: number, displayFullValue?: boolean) {
+  // zero
+  if (bn.isZero()) {
+    return {
+      displayValue: type === 'fiat' ? bn.toFixed(decimals) : bn.toFormat()
+    }
+  }
+
   const value = bn.decimalPlaces(decimals, BigNumber.ROUND_FLOOR)
 
   // minimum display value
@@ -104,7 +111,7 @@ export function displayValueData(sourceValue: SourceValue, params: DisplayValueD
       const displayedDecimals = displayDecimals ? 2 : 0
       const value = bn.shiftedBy(-decimals).multipliedBy(nativeCurrency)
 
-      if (isTestnet || value.isNaN()) {
+      if (isTestnet || value.isNaN() || !currencyRate) {
         return {
           value,
           displayValue: '?'

--- a/test/resources/utils/displayValue.test.js
+++ b/test/resources/utils/displayValue.test.js
@@ -6,6 +6,11 @@ describe('wei', () => {
     const displayValue = displayValueData(356)
     expect(displayValue.wei()).toStrictEqual({ displayValue: '356', value: BigNumber('356') })
   })
+
+  it('should return a zero wei value', () => {
+    const displayValue = displayValueData(0)
+    expect(displayValue.wei()).toStrictEqual({ displayValue: '0', value: BigNumber('0') })
+  })
 })
 
 describe('gwei', () => {
@@ -18,14 +23,18 @@ describe('gwei', () => {
     const displayValue = displayValueData(356e-18)
     expect(displayValue.gwei()).toStrictEqual({ displayValue: '0', value: BigNumber('0') })
   })
+
+  it('should return a zero gwei value', () => {
+    const displayValue = displayValueData(0)
+    expect(displayValue.gwei()).toStrictEqual({ displayValue: '0', value: BigNumber('0') })
+  })
 })
 
 describe('fiat currency', () => {
-  it('should return zero when no currency rate is provided', () => {
+  it('should return ? when no currency rate is provided', () => {
     const value = displayValueData(356e24)
     expect(value.fiat()).toStrictEqual({
-      approximationSymbol: '<',
-      displayValue: '0.01',
+      displayValue: '?',
       value: BigNumber(0)
     })
   })
@@ -55,6 +64,14 @@ describe('fiat currency', () => {
         value: BigNumber(999.999)
       })
     })
+
+    it('should return a zero value', () => {
+      const value = displayValueData(0, { currencyRate: { price: BigNumber(1.3) } })
+      expect(value.fiat()).toStrictEqual({
+        displayValue: '0.00',
+        value: BigNumber(0)
+      })
+    })
   })
 
   describe('when not displaying decimals', () => {
@@ -72,6 +89,14 @@ describe('fiat currency', () => {
       expect(value.fiat({ displayDecimals: false })).toStrictEqual({
         displayValue: '999',
         value: BigNumber(999.999)
+      })
+    })
+
+    it('should return a zero value', () => {
+      const value = displayValueData(0, { currencyRate: { price: BigNumber(1.3) } })
+      expect(value.fiat({ displayDecimals: false })).toStrictEqual({
+        displayValue: '0',
+        value: BigNumber(0)
       })
     })
   })
@@ -318,6 +343,14 @@ describe('ether currency', () => {
         value: BigNumber(0.000009985678111111)
       })
     })
+
+    it('should return a zero value', () => {
+      const value = displayValueData(0)
+      expect(value.ether()).toStrictEqual({
+        displayValue: '0',
+        value: BigNumber(0)
+      })
+    })
   })
 
   describe('when not displaying decimals', () => {
@@ -335,6 +368,14 @@ describe('ether currency', () => {
       expect(value.ether({ displayDecimals: false })).toStrictEqual({
         displayValue: '999',
         value: BigNumber(999.999)
+      })
+    })
+
+    it('should return a zero value', () => {
+      const value = displayValueData(0)
+      expect(value.ether({ displayDecimals: false })).toStrictEqual({
+        displayValue: '0',
+        value: BigNumber(0)
       })
     })
   })


### PR DESCRIPTION
Re-enabling LIMIT_NAVIGATION_GLOBAL_CHECK as the fix for this check has been merged to EN and released in 1.10.0

EDIT: awaiting 1.10.2 release

https://github.com/doyensec/electronegativity/issues/92