### PR TITLE
update EN actions conf

### DIFF
--- a/.github/workflows/compile-and-test.yml
+++ b/.github/workflows/compile-and-test.yml
@@ -18,8 +18,6 @@ jobs:
           node-version: 16.15.0
       - name: Electronegativity
         uses: doyensec/electronegativity-action@v2.0
-        with:
-          exclude-checks: 'LimitNavigationGlobalCheck'
       - name: Upload sarif
         uses: github/codeql-action/upload-sarif@v2
         with:


### PR DESCRIPTION
Re-enabling LIMIT_NAVIGATION_GLOBAL_CHECK as the fix for this check has been merged to EN and released in 1.10.2

https://github.com/doyensec/electronegativity/issues/92