### PR TITLE
display coin balance with amount first

### DIFF
--- a/app/App/Account/Account/Requests/TransactionRequest/TxAction/index.js
+++ b/app/App/Account/Account/Requests/TransactionRequest/TxAction/index.js
@@ -11,7 +11,7 @@ import {
   ClusterValue
 } from '../../../../../../../resources/Components/Cluster'
 import { formatDisplayInteger, isUnlimited } from '../../../../../../../resources/utils/numbers'
-import { DisplayValue } from '../../../../../../../resources/Components/DisplayValue'
+import { DisplayValue, DisplayCoinBalance } from '../../../../../../../resources/Components/DisplayValue'
 import { getAddress } from '../../../../../../../resources/utils'
 
 class TxSending extends React.Component {
@@ -65,12 +65,7 @@ class TxSending extends React.Component {
               <ClusterRow>
                 <ClusterValue grow={2}>
                   <div className='txSendingValue'>
-                    <DisplayValue
-                      type='ether'
-                      value={amount}
-                      valueDataParams={{ decimals }}
-                      currencySymbol={symbol}
-                    />
+                    <DisplayCoinBalance amount={amount} decimals={decimals} symbol={symbol} />
                   </div>
                 </ClusterValue>
                 <ClusterValue>

--- a/app/App/Account/Account/Requests/TransactionRequest/TxFeeNew/index.js
+++ b/app/App/Account/Account/Requests/TransactionRequest/TxFeeNew/index.js
@@ -39,12 +39,12 @@ const USDEstimateDisplay = ({ minFee, maxFee, nativeCurrency }) => {
       <div className={`_txFeeValueDefault${displayMaxFeeWarning ? ' _txFeeValueDefaultWarn' : ''}`}>
         <span>{'≈'}</span>
         {maxFeeApproximation === '<' ? (
-          <DisplayValue type='fiat' valueData={maxFee} currencySymbol='$' />
+          <DisplayValue type='fiat' value={maxFee} currencySymbol='$' />
         ) : (
           <>
-            <DisplayValue type='fiat' valueData={minFee} currencySymbol='$' />
+            <DisplayValue type='fiat' value={minFee} currencySymbol='$' />
             <span>{'-'}</span>
-            <DisplayValue type='fiat' valueData={maxFee} currencySymbol='$' />
+            <DisplayValue type='fiat' value={maxFee} currencySymbol='$' />
           </>
         )}
         <span>{`in ${nativeCurrency.symbol}`}</span>
@@ -101,11 +101,7 @@ class TxFee extends React.Component {
             <ClusterColumn grow={2}>
               <ClusterValue>
                 <div className='txSendingValue'>
-                  <DisplayCoinBalance
-                    amount={maxFee.wei().value.toString()}
-                    decimals={18}
-                    symbol={nativeCurrency.symbol}
-                  />
+                  <DisplayCoinBalance amount={maxFee} symbol={nativeCurrency.symbol} />
                 </div>
               </ClusterValue>
               <ClusterValue>

--- a/app/App/Account/Account/Requests/TransactionRequest/TxFeeNew/index.js
+++ b/app/App/Account/Account/Requests/TransactionRequest/TxFeeNew/index.js
@@ -2,7 +2,7 @@ import React from 'react'
 import Restore from 'react-restore'
 import BigNumber from 'bignumber.js'
 
-import { DisplayValue } from '../../../../../../../resources/Components/DisplayValue'
+import { DisplayCoinBalance, DisplayValue } from '../../../../../../../resources/Components/DisplayValue'
 import { GasFeesSource, usesBaseFee } from '../../../../../../../resources/domain/transaction'
 import { displayValueData } from '../../../../../../../resources/utils/displayValue'
 import link from '../../../../../../../resources/link'
@@ -101,7 +101,11 @@ class TxFee extends React.Component {
             <ClusterColumn grow={2}>
               <ClusterValue>
                 <div className='txSendingValue'>
-                  <DisplayValue type='ether' valueData={maxFee} currencySymbol={nativeCurrency.symbol} />
+                  <DisplayCoinBalance
+                    amount={maxFee.wei().value.toString()}
+                    decimals={18}
+                    symbol={nativeCurrency.symbol}
+                  />
                 </div>
               </ClusterValue>
               <ClusterValue>

--- a/app/App/Account/Account/Requests/TransactionRequest/TxFeeNew/index.js
+++ b/app/App/Account/Account/Requests/TransactionRequest/TxFeeNew/index.js
@@ -101,11 +101,7 @@ class TxFee extends React.Component {
             <ClusterColumn grow={2}>
               <ClusterValue>
                 <div className='txSendingValue'>
-                  <DisplayCoinBalance
-                    amount={maxFee.wei().value.toString()}
-                    decimals={18}
-                    symbol={nativeCurrency.symbol}
-                  />
+                  <DisplayCoinBalance amount={maxFee.wei().value} symbol={nativeCurrency.symbol} />
                 </div>
               </ClusterValue>
               <ClusterValue>

--- a/resources/Components/DisplayValue/index.js
+++ b/resources/Components/DisplayValue/index.js
@@ -15,6 +15,16 @@ const Main = ({ displayValue }) => <span className='displayValueMain'>{displayVa
 
 const Unit = ({ displayUnit }) => <span className='displayValueUnit'>{displayUnit.shortName}</span>
 
+export const DisplayCoinBalance = ({ amount, decimals, symbol }) => (
+  <DisplayValue
+    type='ether'
+    value={amount}
+    valueDataParams={{ decimals }}
+    currencySymbol={symbol}
+    currencySymbolPosition='last'
+  />
+)
+
 export const DisplayFiatPrice = ({ decimals, currencyRate, isTestnet }) => (
   <DisplayValue
     type='fiat'

--- a/resources/Components/DisplayValue/index.js
+++ b/resources/Components/DisplayValue/index.js
@@ -1,5 +1,10 @@
 import React from 'react'
 import { displayValueData } from '../../utils/displayValue'
+import BigNumber from 'bignumber.js'
+
+function isDisplayValueData(obj) {
+  return obj?.fiat && obj?.ether && obj?.gwei && obj?.wei && BigNumber.isBigNumber(obj.bn)
+}
 
 const ApproximateValue = ({ approximationSymbol }) => (
   <span className='displayValueApprox'>{approximationSymbol}</span>
@@ -15,14 +20,8 @@ const Main = ({ displayValue }) => <span className='displayValueMain'>{displayVa
 
 const Unit = ({ displayUnit }) => <span className='displayValueUnit'>{displayUnit.shortName}</span>
 
-export const DisplayCoinBalance = ({ amount, decimals, symbol }) => (
-  <DisplayValue
-    type='ether'
-    value={amount}
-    valueDataParams={{ decimals }}
-    currencySymbol={symbol}
-    currencySymbolPosition='last'
-  />
+export const DisplayCoinBalance = ({ amount, symbol }) => (
+  <DisplayValue type='ether' value={amount} currencySymbol={symbol} currencySymbolPosition='last' />
 )
 
 export const DisplayFiatPrice = ({ decimals, currencyRate, isTestnet }) => (
@@ -37,7 +36,6 @@ export const DisplayFiatPrice = ({ decimals, currencyRate, isTestnet }) => (
 export const DisplayValue = (props) => {
   const {
     value,
-    valueData,
     valueDataParams,
     currencySymbol,
     type = 'ether',
@@ -45,7 +43,7 @@ export const DisplayValue = (props) => {
     currencySymbolPosition = 'first'
   } = props
 
-  const data = valueData || displayValueData(value, valueDataParams)
+  const data = isDisplayValueData(value) ? value : displayValueData(value, valueDataParams)
 
   const { approximationSymbol = '', displayValue, displayUnit } = data[type]({ displayDecimals })
 

--- a/resources/utils/displayValue.ts
+++ b/resources/utils/displayValue.ts
@@ -95,8 +95,35 @@ type DisplayValueDataParams = {
 }
 
 type SourceValue = string | number | BigNumber
+type DisplayUnit = {
+  fullName: string
+  shortName: string
+}
+export type DisplayValueData = {
+  fiat: () => {
+    value: BigNumber
+    displayValue: string
+    approximationSymbol?: string
+    displayUnit?: DisplayUnit
+  }
+  ether: () => {
+    value: BigNumber
+    displayValue: string
+    approximationSymbol?: string
+    displayUnit?: DisplayUnit
+  }
+  gwei: () => {
+    value: BigNumber
+    displayValue: string
+  }
+  wei: () => {
+    value: BigNumber
+    displayValue: string
+  }
+  bn: BigNumber
+}
 
-export function displayValueData(sourceValue: SourceValue, params: DisplayValueDataParams) {
+export function displayValueData(sourceValue: SourceValue, params: DisplayValueDataParams): DisplayValueData {
   const {
     currencyRate,
     decimals = 18,

--- a/test/resources/Components/DisplayValue/index.test.js
+++ b/test/resources/Components/DisplayValue/index.test.js
@@ -6,7 +6,7 @@ import { displayValueData } from '../../../../resources/utils/displayValue'
 
 it('should render the expected content when provided with valueData', () => {
   const valueData = new displayValueData(356e28)
-  const { getByTestId } = setupComponent(<DisplayValue valueData={valueData} />)
+  const { getByTestId } = setupComponent(<DisplayValue value={valueData} />)
   const displayValue = getByTestId('display-value')
 
   expect(displayValue.textContent).toBe('3.56T')


### PR DESCRIPTION
* Amending the gas native currency display in transactions to show the amount first
* Explicit typing for `displayValueData`
* Removing the `valueData` prop in the core DisplayValue component, replaced with duck-typing of `value`