### PR TITLE
remove launcher references, prevent crash when account is removed

### DIFF
--- a/app/tray/Account/Account/index.js
+++ b/app/tray/Account/Account/index.js
@@ -10,7 +10,6 @@ import Activity from './Activity'
 import Balances from './Balances'
 import Gas from '../../../../resources/Components/Gas'
 import Inventory from './Inventory'
-import Launcher from './Launcher'
 import Permissions from './Permissions'
 import Requests from './Requests'
 import Settings from './Settings'
@@ -46,8 +45,6 @@ class _AccountModule extends React.Component {
       <Requests moduleId={id} account={account} expanded={expanded} filter={filter} />
     ) : id === 'activity' ? (
       <Activity moduleId={id} id={account} expanded={expanded} filter={filter} />
-    ) : id === 'launcher' ? (
-      <Launcher moduleId={id} id={account} expanded={expanded} filter={filter} />
     ) : id === 'inventory' ? (
       <Inventory
         moduleId={id}

--- a/app/tray/Account/Account/style/index.styl
+++ b/app/tray/Account/Account/style/index.styl
@@ -890,7 +890,6 @@
 @import '../Inventory/style'
 @import '../Permissions/style'
 @import '../Requests/style'
-@import '../Launcher/style'
 @import '../Settings/style'
 @import '../Signer/style'
 

--- a/app/tray/AccountSelector/AccountController/index.js
+++ b/app/tray/AccountSelector/AccountController/index.js
@@ -234,7 +234,8 @@ class Account extends React.Component {
   }
 
   renderDetails() {
-    const { address, ensName, active } = this.store('main.accounts', this.props.id)
+    const { address, ensName } = this.store('main.accounts', this.props.id)
+    const showLocal = this.store('main.showLocalNameWithENS')
     const formattedAddress = getAddress(address)
 
     let requests = this.store('main.accounts', this.props.id, 'requests') || {}
@@ -261,7 +262,7 @@ class Account extends React.Component {
         </div>
       )
     } else {
-      if (ensName && !this.store('main.showLocalNameWithENS')) {
+      if (ensName && !showLocal) {
         return (
           <div className='signerDetails'>
             <div
@@ -419,6 +420,12 @@ class Account extends React.Component {
     const initialIndex = this.store('selected.position.initial.index')
     const account = this.store('main.accounts', id)
     const isAddAccountView = this.store('view.addAccount')
+
+    if (!account) {
+      // TODO: why is this rendering if the account is gone?
+      console.warn('no account!')
+      return
+    }
 
     const current = selectedAccountId === id && status === 'ok'
     const selectedAccountOpen = current && open


### PR DESCRIPTION
Seems that when we remove an account sometimes we try to render the account after it's been removed from the store but before the parent re-renders. Need to dig into this a little more deeply to figure out the rendering order.