### PR TITLE
ensure block updates continue after computer is suspended

### DIFF
--- a/main/chains/blocks/index.ts
+++ b/main/chains/blocks/index.ts
@@ -62,6 +62,8 @@ class BlockMonitor extends EventEmitter {
   }
 
   start() {
+    log.verbose(`Starting block updates for chain ${parseInt(this.connection.chainId)}`)
+
     this.connection.on('message', this.handleMessage)
 
     // load the latest block first on connect, then start checking for new blocks
@@ -79,6 +81,8 @@ class BlockMonitor extends EventEmitter {
   }
 
   stop() {
+    log.verbose(`Stopping block updates for chain ${parseInt(this.connection.chainId)}`)
+
     this.removeAllListeners()
     this.connection.off('connect', this.start)
     this.connection.off('close', this.stop)

--- a/main/chains/blocks/index.ts
+++ b/main/chains/blocks/index.ts
@@ -57,8 +57,8 @@ class BlockMonitor extends EventEmitter {
 
     this.latestBlock = '0x0'
 
-    this.connection.once('connect', this.start)
-    this.connection.once('close', this.stop)
+    this.connection.on('connect', this.start)
+    this.connection.on('close', this.stop)
   }
 
   start() {
@@ -120,6 +120,10 @@ class BlockMonitor extends EventEmitter {
   }
 
   private handleBlock(block: Block) {
+    log.debug(`Handling block ${parseInt(block.number)} for chain ${parseInt(this.connection.chainId)}`, {
+      latestBlock: this.latestBlock
+    })
+
     if (!block) return this.handleError('handleBlock received undefined block')
 
     if (block.number !== this.latestBlock) {

--- a/main/chains/blocks/index.ts
+++ b/main/chains/blocks/index.ts
@@ -84,8 +84,6 @@ class BlockMonitor extends EventEmitter {
     log.verbose(`Stopping block updates for chain ${parseInt(this.connection.chainId)}`)
 
     this.removeAllListeners()
-    this.connection.off('connect', this.start)
-    this.connection.off('close', this.stop)
 
     if (this.subscriptionId) {
       this.clearSubscription()

--- a/main/chains/index.js
+++ b/main/chains/index.js
@@ -304,6 +304,11 @@ class ChainConnection extends EventEmitter {
           this.emit('close')
         })
         this.secondary.provider.on('status', (status) => {
+          log.debug(
+            `%cUpdated status from secondary provider for chain ${this.chainId}: ${status}`,
+            'color: red'
+          )
+
           if (status === 'connected' && this.secondary.network && this.secondary.network !== this.chainId) {
             this.secondary.connected = false
             this.secondary.type = ''
@@ -371,6 +376,11 @@ class ChainConnection extends EventEmitter {
           this.emit('close')
         })
         this.primary.provider.on('status', (status) => {
+          log.debug(
+            `%cUpdated status from primary provider for chain ${this.chainId}: ${status}`,
+            'color: red'
+          )
+
           if (status === 'connected' && this.primary.network && this.primary.network !== this.chainId) {
             this.primary.connected = false
             this.primary.type = ''

--- a/main/chains/index.js
+++ b/main/chains/index.js
@@ -84,6 +84,7 @@ class ChainConnection extends EventEmitter {
     const allowEip1559 = !legacyChains.includes(parseInt(this.chainId))
 
     monitor.on('data', async (block) => {
+      log.debug(`%cReceived block ${parseInt(block.number)} for chain ${this.chainId}`, 'color: yellow')
       let feeMarket = null
 
       const gasMonitor = new GasMonitor(provider)

--- a/main/chains/index.js
+++ b/main/chains/index.js
@@ -71,6 +71,7 @@ class ChainConnection extends EventEmitter {
       infuraId: '786ade30f36244469480aa5c2bf0743b',
       alchemyId: 'NBms1eV9i16RFHpFqQxod56OLdlucIq0'
     })
+
     this[priority].blockMonitor = this._createBlockMonitor(this[priority].provider, priority)
   }
 
@@ -84,7 +85,6 @@ class ChainConnection extends EventEmitter {
     const allowEip1559 = !legacyChains.includes(parseInt(this.chainId))
 
     monitor.on('data', async (block) => {
-      log.debug(`%cReceived block ${parseInt(block.number)} for chain ${this.chainId}`, 'color: yellow')
       let feeMarket = null
 
       const gasMonitor = new GasMonitor(provider)
@@ -304,11 +304,6 @@ class ChainConnection extends EventEmitter {
           this.emit('close')
         })
         this.secondary.provider.on('status', (status) => {
-          log.debug(
-            `%cUpdated status from secondary provider for chain ${this.chainId}: ${status}`,
-            'color: red'
-          )
-
           if (status === 'connected' && this.secondary.network && this.secondary.network !== this.chainId) {
             this.secondary.connected = false
             this.secondary.type = ''
@@ -376,11 +371,6 @@ class ChainConnection extends EventEmitter {
           this.emit('close')
         })
         this.primary.provider.on('status', (status) => {
-          log.debug(
-            `%cUpdated status from primary provider for chain ${this.chainId}: ${status}`,
-            'color: red'
-          )
-
           if (status === 'connected' && this.primary.network && this.primary.network !== this.chainId) {
             this.primary.connected = false
             this.primary.type = ''

--- a/main/index.ts
+++ b/main/index.ts
@@ -31,7 +31,13 @@ app.commandLine.appendSwitch('force-color-profile', 'srgb')
 
 const isDev = process.env.NODE_ENV === 'development'
 log.transports.console.level = process.env.LOG_LEVEL || (isDev ? 'verbose' : 'info')
-log.transports.file.level = ['development', 'test'].includes(process.env.NODE_ENV) ? false : 'verbose'
+
+if (process.env.LOG_LEVEL === 'debug') {
+  log.transports.file.level = 'debug'
+  log.transports.file.resolvePath = () => path.join(app.getPath('userData'), 'logs/test.log')
+} else {
+  log.transports.file.level = ['development', 'test'].includes(process.env.NODE_ENV) ? false : 'verbose'
+}
 
 const hasInstanceLock = app.requestSingleInstanceLock()
 

--- a/main/index.ts
+++ b/main/index.ts
@@ -34,7 +34,7 @@ log.transports.console.level = process.env.LOG_LEVEL || (isDev ? 'verbose' : 'in
 
 if (process.env.LOG_LEVEL === 'debug') {
   log.transports.file.level = 'debug'
-  log.transports.file.resolvePath = () => path.join(app.getPath('userData'), 'logs/test.log')
+  log.transports.file.resolvePath = () => path.join(app.getPath('userData'), 'logs/debug.log')
 } else {
   log.transports.file.level = ['development', 'test'].includes(process.env.NODE_ENV) ? false : 'verbose'
 }


### PR DESCRIPTION
We were removing connection listeners for new blocks when a connection was closed but not adding them back when the connection was opened again.