### PR TITLE
Arm64 linux builds

### DIFF
--- a/electron-builder.json
+++ b/electron-builder.json
@@ -3,7 +3,8 @@
   "afterSign": "./build/notarize.js",
   "productName": "Frame Canary",
   "linux": {
-    "target": ["AppImage", "deb", "snap", "tar.gz"]
+    "target": ["AppImage", "deb", "snap", "tar.gz"],
+    "arch": ["x64", "arm64"]
   },
   "mac": {
     "target": {

--- a/electron-builder.json
+++ b/electron-builder.json
@@ -3,8 +3,24 @@
   "afterSign": "./build/notarize.js",
   "productName": "Frame Canary",
   "linux": {
-    "target": ["AppImage", "deb", "snap", "tar.gz"],
-    "arch": ["x64", "arm64"]
+    "target": [
+      {
+        "target": "AppImage",
+        "arch": ["x64", "arm64"]
+      },
+      {
+        "target": "deb",
+        "arch": ["x64", "arm64"]
+      },
+      {
+        "target": "snap",
+        "arch": ["x64"]
+      },
+      {
+        "target": "tar.gz",
+        "arch": ["x64", "arm64"]
+      }
+    ]
   },
   "mac": {
     "target": {


### PR DESCRIPTION
Adding (untested) arm64 builds for AppImage, deb and tar.gz

Snapcraft does not currently support building arm64 on amd64 and Github runners do not support arm64 natively:
https://github.com/actions/runner-images/issues/5631