### PR TITLE
Fix Win11 virtual desktops

### DIFF
--- a/main/windows/index.ts
+++ b/main/windows/index.ts
@@ -271,6 +271,7 @@ export class Tray {
       visibleOnFullScreen: true,
       skipTransformProcessType: true
     })
+    windows.tray.setSkipTaskbar(false)
     windows.tray.setResizable(false) // Keeps height consistent
     const area = screen.getDisplayNearestPoint(screen.getCursorScreenPoint()).workArea
     const height = isDev && !fullheight ? devHeight : area.height
@@ -351,6 +352,7 @@ class Dash {
         visibleOnFullScreen: true,
         skipTransformProcessType: true
       })
+      windows.dash.setSkipTaskbar(false)
       windows.dash.setResizable(false) // Keeps height consistent
       const area = screen.getDisplayNearestPoint(screen.getCursorScreenPoint()).workArea
       const height = isDev && !fullheight ? devHeight : area.height

--- a/main/windows/systemTray.ts
+++ b/main/windows/systemTray.ts
@@ -23,7 +23,6 @@ export class SystemTray {
     // Electron Tray can only be instantiated when the app is ready
     this.electronTray = new ElectronTray(path.join(__dirname, isMacOS ? './IconTemplate.png' : './Icon.png'))
     this.electronTray.on('click', (_event: KeyboardEvent, bounds: Rectangle) => {
-      console.log('click systray', _event, bounds)
       const mainWindowBounds = mainWindow.getBounds()
       const currentDisplay = screen.getDisplayMatching(bounds)
       const trayClickDisplay = screen.getDisplayMatching(mainWindowBounds)

--- a/main/windows/systemTray.ts
+++ b/main/windows/systemTray.ts
@@ -23,6 +23,7 @@ export class SystemTray {
     // Electron Tray can only be instantiated when the app is ready
     this.electronTray = new ElectronTray(path.join(__dirname, isMacOS ? './IconTemplate.png' : './Icon.png'))
     this.electronTray.on('click', (_event: KeyboardEvent, bounds: Rectangle) => {
+      console.log('click systray', _event, bounds)
       const mainWindowBounds = mainWindow.getBounds()
       const currentDisplay = screen.getDisplayMatching(bounds)
       const trayClickDisplay = screen.getDisplayMatching(mainWindowBounds)


### PR DESCRIPTION
Fixing the display of Frame on all Windows virtual desktops at once by using the taskbar