### PR TITLE
Upgrade trezor

### DIFF
--- a/main/signers/trezor/Trezor/index.ts
+++ b/main/signers/trezor/Trezor/index.ts
@@ -2,7 +2,7 @@ import log from 'electron-log'
 import { hexToInt } from '../../../../resources/utils'
 import { padToEven, stripHexPrefix, addHexPrefix } from '@ethereumjs/util'
 import { SignTypedDataVersion, TypedDataUtils } from '@metamask/eth-sig-util'
-import type { Device as TrezorDevice } from 'trezor-connect'
+import type { Device as TrezorDevice } from '@trezor/connect'
 import { TypedTransaction } from '@ethereumjs/tx'
 
 import { v5 as uuid } from 'uuid'

--- a/main/signers/trezor/adapter.ts
+++ b/main/signers/trezor/adapter.ts
@@ -1,6 +1,6 @@
 import log from 'electron-log'
 
-import type { Device as TrezorDevice } from 'trezor-connect'
+import type { Device as TrezorDevice } from '@trezor/connect'
 
 import { SignerAdapter } from '../adapters'
 import Trezor, { Status } from './Trezor'

--- a/main/signers/trezor/bridge.ts
+++ b/main/signers/trezor/bridge.ts
@@ -10,7 +10,7 @@ import TrezorConnect, {
   DEVICE_EVENT,
   UI,
   UI_EVENT
-} from 'trezor-connect'
+} from '@trezor/connect'
 
 export class DeviceError extends Error {
   readonly code

--- a/package-lock.json
+++ b/package-lock.json
@@ -23,6 +23,7 @@
         "@ledgerhq/hw-transport-web-ble": "6.27.8",
         "@metamask/eth-sig-util": "5.0.2",
         "@sentry/electron": "4.1.2",
+        "@trezor/connect": "9.0.5",
         "auto-launch": "5.0.5",
         "bip39": "3.0.4",
         "cheerio": "1.0.0-rc.12",
@@ -53,7 +54,6 @@
         "rlp": "3.0.0",
         "semver": "7.3.8",
         "styled-components": "5.3.6",
-        "trezor-connect": "8.2.12-extended",
         "uuid": "9.0.0",
         "ws": "8.11.0",
         "zxcvbn": "4.4.2"
@@ -9853,42 +9853,70 @@
         }
       }
     },
-    "node_modules/@trezor/connect-common": {
-      "version": "0.0.10",
-      "resolved": "https://registry.npmjs.org/@trezor/connect-common/-/connect-common-0.0.10.tgz",
-      "integrity": "sha512-bwqB5J6IrLBZ/tGQw/C/EoYZW6Jpjf6ch9sYUog4EVTNIqh5nCLP+g8ShSyco9lvrKInMDXDWwU6OsEZE5gcPQ=="
-    },
-    "node_modules/@trezor/rollout": {
-      "version": "1.3.2",
-      "resolved": "https://registry.npmjs.org/@trezor/rollout/-/rollout-1.3.2.tgz",
-      "integrity": "sha512-P660yMKCM0rKJZXEH+YmTYXLdrxcKquapSnC7YUa5cf0jVG8rNQLeETnaS6YnYjbYXRxtmUWL/537bfj6dZeWw==",
+    "node_modules/@trezor/connect": {
+      "version": "9.0.5",
+      "resolved": "https://registry.npmjs.org/@trezor/connect/-/connect-9.0.5.tgz",
+      "integrity": "sha512-1ctd91l3y42TCP8j4AuHsHa0+KGthAh7wl1g2vgEV0JTChEcUfVQBHqkOwcAAA1yvS81NVaJ59tEnHZpySBWnw==",
       "dependencies": {
-        "@trezor/utils": "^1.0.0",
+        "@trezor/blockchain-link": "^2.1.6",
+        "@trezor/connect-common": "0.0.11",
+        "@trezor/transport": "^1.1.6",
+        "@trezor/utils": "^9.0.4",
+        "@trezor/utxo-lib": "^1.0.2",
+        "bignumber.js": "^9.1.0",
+        "blakejs": "^1.2.1",
+        "bowser": "^2.11.0",
         "cross-fetch": "^3.1.5",
-        "runtypes": "^6.5.1"
+        "events": "^3.3.0",
+        "parse-uri": "1.0.7",
+        "randombytes": "2.1.0"
       }
     },
-    "node_modules/@trezor/rollout/node_modules/@trezor/utils": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@trezor/utils/-/utils-1.0.1.tgz",
-      "integrity": "sha512-+XYu51Zc3eM6bc8e1C3xrGHpryj6HsI4Gy3fdjhs8qiYGlVBJ6yMOsuNB4k2JHQiBNyhSn6Jw+VztH+ZYps1kQ=="
+    "node_modules/@trezor/connect/node_modules/@trezor/connect-common": {
+      "version": "0.0.11",
+      "resolved": "https://registry.npmjs.org/@trezor/connect-common/-/connect-common-0.0.11.tgz",
+      "integrity": "sha512-17a4EuNGB842DTogEO49zANDmgNYYdegpB6E6jQPaPEzSryib5LdW9EkZin8KzAnqq+igv3bV18X4wIDjoHDgQ=="
     },
-    "node_modules/@trezor/transport": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/@trezor/transport/-/transport-1.1.2.tgz",
-      "integrity": "sha512-Fh81+R/SQmaRcfT6efAOf9xsgxXxPW9tEcREe8tiou3HVPITyQOCKvC5+1R8lqEPZRTZnil0l22a1c/cfFpIww==",
+    "node_modules/@trezor/connect/node_modules/@trezor/transport": {
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/@trezor/transport/-/transport-1.1.6.tgz",
+      "integrity": "sha512-bkxNqz4VV0RFnaL4f1zzru9oa261qkHsloIH4G1utHIZ/lArtKiv9GkuxLiwm3DF6k3sWhr1qjecRQryb+O58g==",
       "dependencies": {
-        "@trezor/utils": "^1.0.0",
+        "@trezor/utils": "^9.0.4",
         "bytebuffer": "^5.0.1",
-        "json-stable-stringify": "^1.0.1",
+        "json-stable-stringify": "^1.0.2",
         "long": "^4.0.0",
-        "protobufjs": "^6.11.2"
+        "prettier": "2.8.0",
+        "protobufjs": "^7.1.2"
       }
     },
-    "node_modules/@trezor/transport/node_modules/@trezor/utils": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@trezor/utils/-/utils-1.0.1.tgz",
-      "integrity": "sha512-+XYu51Zc3eM6bc8e1C3xrGHpryj6HsI4Gy3fdjhs8qiYGlVBJ6yMOsuNB4k2JHQiBNyhSn6Jw+VztH+ZYps1kQ=="
+    "node_modules/@trezor/connect/node_modules/protobufjs": {
+      "version": "7.1.2",
+      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.1.2.tgz",
+      "integrity": "sha512-4ZPTPkXCdel3+L81yw3dG6+Kq3umdWKh7Dc7GW/CpNk4SX3hK58iPCWeCyhVTDrbkNeKrYNZ7EojM5WDaEWTLQ==",
+      "hasInstallScript": true,
+      "dependencies": {
+        "@protobufjs/aspromise": "^1.1.2",
+        "@protobufjs/base64": "^1.1.2",
+        "@protobufjs/codegen": "^2.0.4",
+        "@protobufjs/eventemitter": "^1.1.0",
+        "@protobufjs/fetch": "^1.1.0",
+        "@protobufjs/float": "^1.0.2",
+        "@protobufjs/inquire": "^1.1.0",
+        "@protobufjs/path": "^1.1.2",
+        "@protobufjs/pool": "^1.1.0",
+        "@protobufjs/utf8": "^1.1.0",
+        "@types/node": ">=13.7.0",
+        "long": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
+    "node_modules/@trezor/connect/node_modules/protobufjs/node_modules/long": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/long/-/long-5.2.1.tgz",
+      "integrity": "sha512-GKSNGeNAtw8IryjjkhZxuKB3JzlcLTwjtiQCHKvqQet81I93kXslhDQruGI/QsddO83mcDToBVy7GqGS/zYf/A=="
     },
     "node_modules/@trezor/utils": {
       "version": "9.0.4",
@@ -12357,19 +12385,6 @@
       },
       "engines": {
         "node": ">=12.19"
-      }
-    },
-    "node_modules/cbor-web": {
-      "version": "7.0.6",
-      "resolved": "https://registry.npmjs.org/cbor-web/-/cbor-web-7.0.6.tgz",
-      "integrity": "sha512-A6ZH12jcDJG9PS7StugO78G+ok23SAjxMugGInPBy4IItiH6hYzybi6HQkGjWw9jBEGQpIBkleB2mizxYZIpLw==",
-      "peerDependencies": {
-        "bignumber.js": "^9.0.1"
-      },
-      "peerDependenciesMeta": {
-        "bignumber.js": {
-          "optional": true
-        }
       }
     },
     "node_modules/cborg": {
@@ -23392,7 +23407,6 @@
       "version": "2.8.0",
       "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.8.0.tgz",
       "integrity": "sha512-9Lmg8hTFZKG0Asr/kW9Bp8tJjRVluO8EJQVfY2T7FMw9T5jy4I/Uvx0Rca/XWf50QQ1/SS48+6IJWnrb+2yemA==",
-      "dev": true,
       "bin": {
         "prettier": "bin-prettier.js"
       },
@@ -24414,11 +24428,6 @@
       "dependencies": {
         "queue-microtask": "^1.2.2"
       }
-    },
-    "node_modules/runtypes": {
-      "version": "6.6.0",
-      "resolved": "https://registry.npmjs.org/runtypes/-/runtypes-6.6.0.tgz",
-      "integrity": "sha512-ddM7sgB3fyboDlBzEYFQ04L674sKjbs4GyW2W32N/5Ae47NRd/GyMASPC2PFw8drPHYGEcZ0mZ26r5RcB8msfQ=="
     },
     "node_modules/rustbn.js": {
       "version": "0.2.0",
@@ -25864,26 +25873,6 @@
       "dev": true,
       "bin": {
         "tree-kill": "cli.js"
-      }
-    },
-    "node_modules/trezor-connect": {
-      "version": "8.2.12-extended",
-      "resolved": "https://registry.npmjs.org/trezor-connect/-/trezor-connect-8.2.12-extended.tgz",
-      "integrity": "sha512-/NH6+rKWT7Ie3FS38S6KK+OWqqXdwCEor09RXIXVE3S14Y9TqhXcBzzs3k8/hNFHRevU0jIBxFbfI7hZKktGrQ==",
-      "dependencies": {
-        "@babel/runtime": "^7.15.4",
-        "@trezor/blockchain-link": "^2.1.3",
-        "@trezor/connect-common": "^0.0.10",
-        "@trezor/rollout": "^1.3.2",
-        "@trezor/transport": "1.1.2",
-        "@trezor/utxo-lib": "^1.0.0",
-        "bignumber.js": "^9.0.2",
-        "bowser": "^2.11.0",
-        "cbor-web": "^7.0.6",
-        "cross-fetch": "^3.1.5",
-        "events": "^3.3.0",
-        "parse-uri": "^1.0.5",
-        "randombytes": "2.1.0"
       }
     },
     "node_modules/trim-right": {
@@ -33647,44 +33636,68 @@
         }
       }
     },
-    "@trezor/connect-common": {
-      "version": "0.0.10",
-      "resolved": "https://registry.npmjs.org/@trezor/connect-common/-/connect-common-0.0.10.tgz",
-      "integrity": "sha512-bwqB5J6IrLBZ/tGQw/C/EoYZW6Jpjf6ch9sYUog4EVTNIqh5nCLP+g8ShSyco9lvrKInMDXDWwU6OsEZE5gcPQ=="
-    },
-    "@trezor/rollout": {
-      "version": "1.3.2",
-      "resolved": "https://registry.npmjs.org/@trezor/rollout/-/rollout-1.3.2.tgz",
-      "integrity": "sha512-P660yMKCM0rKJZXEH+YmTYXLdrxcKquapSnC7YUa5cf0jVG8rNQLeETnaS6YnYjbYXRxtmUWL/537bfj6dZeWw==",
+    "@trezor/connect": {
+      "version": "9.0.5",
+      "resolved": "https://registry.npmjs.org/@trezor/connect/-/connect-9.0.5.tgz",
+      "integrity": "sha512-1ctd91l3y42TCP8j4AuHsHa0+KGthAh7wl1g2vgEV0JTChEcUfVQBHqkOwcAAA1yvS81NVaJ59tEnHZpySBWnw==",
       "requires": {
-        "@trezor/utils": "^1.0.0",
+        "@trezor/blockchain-link": "^2.1.6",
+        "@trezor/connect-common": "0.0.11",
+        "@trezor/transport": "^1.1.6",
+        "@trezor/utils": "^9.0.4",
+        "@trezor/utxo-lib": "^1.0.2",
+        "bignumber.js": "^9.1.0",
+        "blakejs": "^1.2.1",
+        "bowser": "^2.11.0",
         "cross-fetch": "^3.1.5",
-        "runtypes": "^6.5.1"
+        "events": "^3.3.0",
+        "parse-uri": "1.0.7",
+        "randombytes": "2.1.0"
       },
       "dependencies": {
-        "@trezor/utils": {
-          "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/@trezor/utils/-/utils-1.0.1.tgz",
-          "integrity": "sha512-+XYu51Zc3eM6bc8e1C3xrGHpryj6HsI4Gy3fdjhs8qiYGlVBJ6yMOsuNB4k2JHQiBNyhSn6Jw+VztH+ZYps1kQ=="
-        }
-      }
-    },
-    "@trezor/transport": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/@trezor/transport/-/transport-1.1.2.tgz",
-      "integrity": "sha512-Fh81+R/SQmaRcfT6efAOf9xsgxXxPW9tEcREe8tiou3HVPITyQOCKvC5+1R8lqEPZRTZnil0l22a1c/cfFpIww==",
-      "requires": {
-        "@trezor/utils": "^1.0.0",
-        "bytebuffer": "^5.0.1",
-        "json-stable-stringify": "^1.0.1",
-        "long": "^4.0.0",
-        "protobufjs": "^6.11.2"
-      },
-      "dependencies": {
-        "@trezor/utils": {
-          "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/@trezor/utils/-/utils-1.0.1.tgz",
-          "integrity": "sha512-+XYu51Zc3eM6bc8e1C3xrGHpryj6HsI4Gy3fdjhs8qiYGlVBJ6yMOsuNB4k2JHQiBNyhSn6Jw+VztH+ZYps1kQ=="
+        "@trezor/connect-common": {
+          "version": "0.0.11",
+          "resolved": "https://registry.npmjs.org/@trezor/connect-common/-/connect-common-0.0.11.tgz",
+          "integrity": "sha512-17a4EuNGB842DTogEO49zANDmgNYYdegpB6E6jQPaPEzSryib5LdW9EkZin8KzAnqq+igv3bV18X4wIDjoHDgQ=="
+        },
+        "@trezor/transport": {
+          "version": "1.1.6",
+          "resolved": "https://registry.npmjs.org/@trezor/transport/-/transport-1.1.6.tgz",
+          "integrity": "sha512-bkxNqz4VV0RFnaL4f1zzru9oa261qkHsloIH4G1utHIZ/lArtKiv9GkuxLiwm3DF6k3sWhr1qjecRQryb+O58g==",
+          "requires": {
+            "@trezor/utils": "^9.0.4",
+            "bytebuffer": "^5.0.1",
+            "json-stable-stringify": "^1.0.2",
+            "long": "^4.0.0",
+            "prettier": "2.8.0",
+            "protobufjs": "^7.1.2"
+          }
+        },
+        "protobufjs": {
+          "version": "7.1.2",
+          "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.1.2.tgz",
+          "integrity": "sha512-4ZPTPkXCdel3+L81yw3dG6+Kq3umdWKh7Dc7GW/CpNk4SX3hK58iPCWeCyhVTDrbkNeKrYNZ7EojM5WDaEWTLQ==",
+          "requires": {
+            "@protobufjs/aspromise": "^1.1.2",
+            "@protobufjs/base64": "^1.1.2",
+            "@protobufjs/codegen": "^2.0.4",
+            "@protobufjs/eventemitter": "^1.1.0",
+            "@protobufjs/fetch": "^1.1.0",
+            "@protobufjs/float": "^1.0.2",
+            "@protobufjs/inquire": "^1.1.0",
+            "@protobufjs/path": "^1.1.2",
+            "@protobufjs/pool": "^1.1.0",
+            "@protobufjs/utf8": "^1.1.0",
+            "@types/node": ">=13.7.0",
+            "long": "^5.0.0"
+          },
+          "dependencies": {
+            "long": {
+              "version": "5.2.1",
+              "resolved": "https://registry.npmjs.org/long/-/long-5.2.1.tgz",
+              "integrity": "sha512-GKSNGeNAtw8IryjjkhZxuKB3JzlcLTwjtiQCHKvqQet81I93kXslhDQruGI/QsddO83mcDToBVy7GqGS/zYf/A=="
+            }
+          }
         }
       }
     },
@@ -35752,12 +35765,6 @@
       "requires": {
         "nofilter": "^3.1.0"
       }
-    },
-    "cbor-web": {
-      "version": "7.0.6",
-      "resolved": "https://registry.npmjs.org/cbor-web/-/cbor-web-7.0.6.tgz",
-      "integrity": "sha512-A6ZH12jcDJG9PS7StugO78G+ok23SAjxMugGInPBy4IItiH6hYzybi6HQkGjWw9jBEGQpIBkleB2mizxYZIpLw==",
-      "requires": {}
     },
     "cborg": {
       "version": "1.9.6",
@@ -44026,8 +44033,7 @@
     "prettier": {
       "version": "2.8.0",
       "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.8.0.tgz",
-      "integrity": "sha512-9Lmg8hTFZKG0Asr/kW9Bp8tJjRVluO8EJQVfY2T7FMw9T5jy4I/Uvx0Rca/XWf50QQ1/SS48+6IJWnrb+2yemA==",
-      "dev": true
+      "integrity": "sha512-9Lmg8hTFZKG0Asr/kW9Bp8tJjRVluO8EJQVfY2T7FMw9T5jy4I/Uvx0Rca/XWf50QQ1/SS48+6IJWnrb+2yemA=="
     },
     "pretty-format": {
       "version": "27.5.1",
@@ -44795,11 +44801,6 @@
       "requires": {
         "queue-microtask": "^1.2.2"
       }
-    },
-    "runtypes": {
-      "version": "6.6.0",
-      "resolved": "https://registry.npmjs.org/runtypes/-/runtypes-6.6.0.tgz",
-      "integrity": "sha512-ddM7sgB3fyboDlBzEYFQ04L674sKjbs4GyW2W32N/5Ae47NRd/GyMASPC2PFw8drPHYGEcZ0mZ26r5RcB8msfQ=="
     },
     "rustbn.js": {
       "version": "0.2.0",
@@ -45912,26 +45913,6 @@
       "resolved": "https://registry.npmjs.org/tree-kill/-/tree-kill-1.2.2.tgz",
       "integrity": "sha512-L0Orpi8qGpRG//Nd+H90vFB+3iHnue1zSSGmNOOCh1GLJ7rUKVwV2HvijphGQS2UmhUZewS9VgvxYIdgr+fG1A==",
       "dev": true
-    },
-    "trezor-connect": {
-      "version": "8.2.12-extended",
-      "resolved": "https://registry.npmjs.org/trezor-connect/-/trezor-connect-8.2.12-extended.tgz",
-      "integrity": "sha512-/NH6+rKWT7Ie3FS38S6KK+OWqqXdwCEor09RXIXVE3S14Y9TqhXcBzzs3k8/hNFHRevU0jIBxFbfI7hZKktGrQ==",
-      "requires": {
-        "@babel/runtime": "^7.15.4",
-        "@trezor/blockchain-link": "^2.1.3",
-        "@trezor/connect-common": "^0.0.10",
-        "@trezor/rollout": "^1.3.2",
-        "@trezor/transport": "1.1.2",
-        "@trezor/utxo-lib": "^1.0.0",
-        "bignumber.js": "^9.0.2",
-        "bowser": "^2.11.0",
-        "cbor-web": "^7.0.6",
-        "cross-fetch": "^3.1.5",
-        "events": "^3.3.0",
-        "parse-uri": "^1.0.5",
-        "randombytes": "2.1.0"
-      }
     },
     "trim-right": {
       "version": "1.0.1",

--- a/package.json
+++ b/package.json
@@ -99,7 +99,7 @@
     "rlp": "3.0.0",
     "semver": "7.3.8",
     "styled-components": "5.3.6",
-    "trezor-connect": "8.2.12-extended",
+    "@trezor/connect": "9.0.5",
     "uuid": "9.0.0",
     "ws": "8.11.0",
     "zxcvbn": "4.4.2"
@@ -223,11 +223,16 @@
       "@babel/node>core-js": true,
       "@lavamoat/preinstall-always-fail": false,
       "@ledgerhq/hw-transport-node-hid-singleton>usb": false,
+      "@trezor/connect>@trezor/transport>protobufjs": false,
+      "@trezor/connect>@trezor/utxo-lib>blake-hash": false,
+      "@trezor/connect>@trezor/utxo-lib>tiny-secp256k1": false,
       "electron": true,
       "gridplus-sdk": false,
       "hardhat>@nomicfoundation/ethereumjs-blockchain>level>classic-level": false,
       "hardhat>keccak": true,
       "hdkey>secp256k1": true,
+      "nebula>ipfs-http-client>ipfs-core-utils>ipfs-unixfs>protobufjs": false,
+      "nebula>ipfs-http-client>ipfs-core-types>ipfs-unixfs>protobufjs": false,
       "node-hid": false,
       "parcel>@parcel/core>@parcel/cache>lmdb": true,
       "parcel>@parcel/core>msgpackr>msgpackr-extract": false,
@@ -239,8 +244,7 @@
       "trezor-connect>@trezor/utxo-lib>blake-hash": false,
       "trezor-connect>@trezor/utxo-lib>tiny-secp256k1": false,
       "ws>bufferutil": false,
-      "ws>utf-8-validate": false,
-      "nebula>ipfs-http-client>ipfs-core-utils>ipfs-unixfs>protobufjs": false
+      "ws>utf-8-validate": false
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -240,9 +240,6 @@
       "react-restore>babel-core>babel-register>core-js": true,
       "react-restore>babel-core>babel-runtime>core-js": true,
       "styled-components": false,
-      "trezor-connect>@trezor/transport>protobufjs": false,
-      "trezor-connect>@trezor/utxo-lib>blake-hash": false,
-      "trezor-connect>@trezor/utxo-lib>tiny-secp256k1": false,
       "ws>bufferutil": false,
       "ws>utf-8-validate": false
     }

--- a/test/main/signers/trezor/bridge.test.js
+++ b/test/main/signers/trezor/bridge.test.js
@@ -1,10 +1,10 @@
-import TrezorConnect, { DEVICE_EVENT, DEVICE, UI_EVENT, UI } from 'trezor-connect'
+import TrezorConnect, { DEVICE_EVENT, DEVICE, UI_EVENT, UI } from '@trezor/connect'
 import { EventEmitter } from 'stream'
 import log from 'electron-log'
 
 import TrezorBridge from '../../../../main/signers/trezor/bridge'
 
-jest.mock('trezor-connect')
+jest.mock('@trezor/connect')
 
 const events = new EventEmitter()
 


### PR DESCRIPTION
this seems to just work without any code changes.

tested:
 - connecting while Frame is running (both T1 and Trezor T)
 - connecting on startup (both)
 - disconnect/reconnect while Frame is running (both)
 - enter pin (T1)
 - enter passphrase on device (T)
 - enter passphrase in Frame (both)
 - switch derivation between legacy, standard, testnet (both)
 - send transaction on testnet (both)
 - sign eth message and personal message (both)
 - sign typed data v4 (both)