### PR TITLE
Fix Trezor T typed data signing

### DIFF
--- a/main/signers/trezor/Trezor/index.ts
+++ b/main/signers/trezor/Trezor/index.ts
@@ -279,7 +279,7 @@ export default class Trezor extends Signer {
           messageHash
         )
       } else {
-        signature = await TrezorBridge.signTypedData(this.device, path, typedMessage)
+        signature = await TrezorBridge.signTypedData(this.device, path, typedMessage.data)
       }
 
       cb(null, addHexPrefix(signature))

--- a/main/signers/trezor/Trezor/index.ts
+++ b/main/signers/trezor/Trezor/index.ts
@@ -258,25 +258,27 @@ export default class Trezor extends Signer {
       if (this.isTrezorOne()) {
         // Trezor One requires hashed input
         const { types, primaryType, domain, message } = TypedDataUtils.sanitizeData(typedMessage.data)
+
         const domainSeparatorHash = TypedDataUtils.hashStruct(
           'EIP712Domain',
           domain,
           types,
           SignTypedDataVersion.V4
-        ).toString('hex')
+        )
+
         const messageHash = TypedDataUtils.hashStruct(
           primaryType as any,
           message,
           types,
           SignTypedDataVersion.V4
-        ).toString('hex')
+        )
 
         signature = await TrezorBridge.signTypedHash(
           this.device,
           path,
-          typedMessage,
-          domainSeparatorHash,
-          messageHash
+          typedMessage.data,
+          domainSeparatorHash.toString('hex'),
+          messageHash.toString('hex')
         )
       } else {
         signature = await TrezorBridge.signTypedData(this.device, path, typedMessage.data)


### PR DESCRIPTION
The TD versioning / `eth-sig-util` upgrade seems to have introduced a bug where the Trezor T is unable to sign typed data.