### PR TITLE
Render accounts if signer disconnected when in expanded view

### DIFF
--- a/app/dash/App.js
+++ b/app/dash/App.js
@@ -51,10 +51,6 @@ class Dash extends React.Component {
     if (view === 'accounts') return <Accounts data={data} />
     if (view === 'expandedSigner' && data.signer) {
       const signer = this.store('main.signers', data.signer)
-      if (!signer) {
-        link.send('tray:action', 'navClearSigner', data.signer)
-        return null
-      }
       return <Signer expanded={true} key={signer.id + ':expanded'} {...signer} />
     }
     if (view === 'chains') return <Chains data={data} />

--- a/app/dash/App.js
+++ b/app/dash/App.js
@@ -52,7 +52,7 @@ class Dash extends React.Component {
     if (view === 'expandedSigner' && data.signer) {
       const signer = this.store('main.signers', data.signer)
       if (!signer) {
-        link.send('tray:action', 'navDash', { view: 'accounts' })
+        link.send('tray:action', 'navClearSigner', data.signer)
         return null
       }
       return <Signer expanded={true} key={signer.id + ':expanded'} {...signer} />

--- a/app/dash/App.js
+++ b/app/dash/App.js
@@ -51,7 +51,7 @@ class Dash extends React.Component {
     if (view === 'accounts') return <Accounts data={data} />
     if (view === 'expandedSigner' && data.signer) {
       const signer = this.store('main.signers', data.signer)
-      if (!signer) return null
+      if (!signer) return <Accounts data={data} />
       return <Signer expanded={true} key={signer.id + ':expanded'} {...signer} />
     }
     if (view === 'chains') return <Chains data={data} />

--- a/app/dash/App.js
+++ b/app/dash/App.js
@@ -51,7 +51,10 @@ class Dash extends React.Component {
     if (view === 'accounts') return <Accounts data={data} />
     if (view === 'expandedSigner' && data.signer) {
       const signer = this.store('main.signers', data.signer)
-      if (!signer) return <Accounts data={data} />
+      if (!signer) {
+        link.send('tray:action', 'navDash', { view: 'accounts' })
+        return null
+      }
       return <Signer expanded={true} key={signer.id + ':expanded'} {...signer} />
     }
     if (view === 'chains') return <Chains data={data} />

--- a/main/signers/index.ts
+++ b/main/signers/index.ts
@@ -112,6 +112,7 @@ class Signers extends EventEmitter {
     if (signer) {
       delete this.signers[id]
       store.removeSigner(id)
+      store.navClearSigner(id)
 
       const type = signer.type === 'ring' || signer.type === 'seed' ? 'hot' : signer.type
 

--- a/main/store/actions/index.js
+++ b/main/store/actions/index.js
@@ -678,6 +678,9 @@ module.exports = {
       return win
     })
   },
+  navClearSigner: (u, signerId) => {
+    u('windows.dash.nav', (nav) => nav.filter((navItem) => navItem?.data?.signer !== signerId))
+  },
   navClearReq: (u, handlerId, showRequestInbox = true) => {
     u('windows.panel.nav', (nav) => {
       const newNav = nav.filter((navItem) => {

--- a/test/main/store/actions/index.test.js
+++ b/test/main/store/actions/index.test.js
@@ -22,7 +22,8 @@ import {
   activateNetwork as activateNetworkAction,
   setBlockHeight as setBlockHeightAction,
   updateAccount as updateAccountAction,
-  navClearReq as clearNavRequestAction
+  navClearReq as clearNavRequestAction,
+  navClearSigner as clearNavSignerAction
 } from '../../../../main/store/actions'
 import { toTokenId } from '../../../../resources/domain/balance'
 
@@ -1171,6 +1172,45 @@ describe('#removeKnownTokens', () => {
   })
 })
 
+describe('#navClearSigner', () => {
+  let nav
+
+  const updaterFn = (node, update) => {
+    expect(node).toBe('windows.panel.nav')
+
+    nav = update(nav)
+  }
+
+  const clearSigner = clearNavSignerAction.bind(null, updaterFn)
+
+  beforeEach(() => {
+    nav = []
+  })
+
+  it('should remove a specific signer from the nav', () => {
+    nav = [
+      {
+        view: 'expandedSigner',
+        data: {
+          signer: '1a'
+        }
+      },
+      {
+        view: 'expandedSigner',
+        data: {
+          signer: '2b'
+        }
+      }
+    ]
+
+    const [req1, req2] = nav
+
+    clearSigner('2b')
+
+    expect(nav).toStrictEqual([req1])
+  })
+})
+
 describe('#navClearReq', () => {
   let nav
 
@@ -1236,3 +1276,4 @@ describe('#navClearReq', () => {
     expect(nav).toStrictEqual([])
   })
 })
+clearNavSignerAction

--- a/test/main/store/actions/index.test.js
+++ b/test/main/store/actions/index.test.js
@@ -1176,7 +1176,7 @@ describe('#navClearSigner', () => {
   let nav
 
   const updaterFn = (node, update) => {
-    expect(node).toBe('windows.panel.nav')
+    expect(node).toBe('windows.dash.nav')
 
     nav = update(nav)
   }


### PR DESCRIPTION
If you disconnect a signer when in expanded view the current behaviour is to render null - we should render the accounts.