### PR TITLE
call tray readyHandler only once

### DIFF
--- a/main/windows/index.ts
+++ b/main/windows/index.ts
@@ -215,7 +215,7 @@ export class Tray {
         }, 600)
       }
     }
-    ipcMain.on('tray:ready', this.readyHandler)
+    ipcMain.once('tray:ready', this.readyHandler)
     initTrayWindow()
   }
 


### PR DESCRIPTION
Listening for `tray:ready` more than once can cause multiple systray instances if Frame is reloaded with CMD+R in dev.