### PR TITLE
sticky accounts (prototype)

### DIFF
--- a/main/accounts/Account/index.ts
+++ b/main/accounts/Account/index.ts
@@ -274,8 +274,6 @@ class FrameAccount {
 
   lastSelected() {
     const accountMetaId = uuidv5(this.address, accountNS)
-    console.log('looking for accountsMeta', this.address, accountMetaId)
-    console.log(store('main.accountsMeta'))
     const accountMeta = store('main.accountsMeta', accountMetaId)
     return accountMeta?.lastSelected || 0
   }

--- a/main/accounts/Account/index.ts
+++ b/main/accounts/Account/index.ts
@@ -1,5 +1,6 @@
 import log from 'electron-log'
 import { isValidAddress } from '@ethereumjs/util'
+import { v5 as uuidv5 } from 'uuid'
 
 import {
   AccessRequest,
@@ -24,6 +25,7 @@ import reveal from '../../reveal'
 import type { PermitSignatureRequest, TypedMessage } from '../types'
 import { isTransactionRequest, isTypedMessageSignatureRequest } from '../../../resources/domain/request'
 import Erc20Contract from '../../contracts/erc20'
+import { accountNS } from '../../../resources/domain/account'
 
 const nebula = nebulaApi()
 
@@ -268,6 +270,14 @@ class FrameAccount {
         approve
       }
     ]
+  }
+
+  lastSelected() {
+    const accountMetaId = uuidv5(this.address, accountNS)
+    console.log('looking for accountsMeta', this.address, accountMetaId)
+    console.log(store('main.accountsMeta'))
+    const accountMeta = store('main.accountsMeta', accountMetaId)
+    return accountMeta?.lastSelected || 0
   }
 
   resError(err: string | Error, payload: RPCResponsePayload, res: RPCErrorCallback) {

--- a/main/api/origins.ts
+++ b/main/api/origins.ts
@@ -52,10 +52,6 @@ function invalidOrigin(origin: string) {
 async function getPermission(address: Address, origin: string, payload: RPCRequestPayload) {
   const permission = storeApi.checkPermission(address, origin)
 
-  if (!permission) {
-    console.log('requesting perm for ' + address)
-  }
-
   return permission || requestPermission(address, payload)
 }
 
@@ -208,8 +204,6 @@ export async function isTrusted(payload: RPCRequestPayload) {
     .map(([_id, account]) => ({ account, permission: storeApi.checkPermission(account.address, originName) }))
     .filter(({ permission }) => !!permission?.provider)
 
-  console.log('checking perms for ' + originName)
-  console.log(existingPermissions)
   let permission
 
   // get permission for the current account, otherwise use existing perm

--- a/main/provider/index.ts
+++ b/main/provider/index.ts
@@ -964,8 +964,6 @@ export class Provider extends EventEmitter {
 
     const method = payload.method || ''
 
-    console.log('provider send', method)
-
     // method handlers that are not chain-specific can go here, before parsing the target chain
     if (method === 'eth_unsubscribe' && this.ifSubRemove(payload.params[0]))
       return res({ id: payload.id, jsonrpc: '2.0', result: true }) // Subscription was ours
@@ -978,7 +976,6 @@ export class Provider extends EventEmitter {
     }
 
     function getAccounts(payload: RPCRequestPayload, res: RPCRequestCallback) {
-      console.log('getAccounts payload', payload)
       const currentAccount = accounts.current()
       const accountsList = Object.entries(accounts.accounts).sort(
         ([_idA, accountA], [_idB, accountB]) => accountB.lastSelected() - accountA.lastSelected()
@@ -986,7 +983,6 @@ export class Provider extends EventEmitter {
       // move currently selected account to top of the list
       if (currentAccount) {
         accountsList.filter(([_id, account]) => account.id !== currentAccount.id)
-        console.log('setting currentAccount', accountsList)
       }
       const origin = storeApi.getOrigin(payload._origin)
       const existingPermissions = accountsList
@@ -996,30 +992,23 @@ export class Provider extends EventEmitter {
         }))
         .filter(({ permission }) => !!permission?.provider)
 
-      // handle fallback case - selected account without permission should still result in connection to another account
-
       let permission
       let result
 
       // get permission for the current account, otherwise use existing perm
       if (currentAccount) {
-        console.log('current account', currentAccount)
         permission = storeApi.checkPermission(currentAccount.address, origin.name)
 
         // no permission for current account => fall back to checking other accounts
         if (!permission?.provider) {
-          console.log('no perm')
           result = existingPermissions.map(({ account }) => account.address.toLowerCase())
         } else {
-          console.log('perm')
           result = accounts.getSelectedAddresses().map((a) => a.toLowerCase())
         }
       } else {
-        console.log('no current account')
         result = existingPermissions.map(({ account }) => account.address.toLowerCase())
       }
 
-      console.log('res', result)
       res({
         id: payload.id,
         jsonrpc: payload.jsonrpc,

--- a/main/store/actions/index.js
+++ b/main/store/actions/index.js
@@ -80,7 +80,7 @@ module.exports = {
       return Object.assign({}, secondary, status)
     })
   },
-  setLaunch: (u, launch) => u('main.launch', (_) => launch),
+  setLaunch: (u, launch) => u('main.launch', () => launch),
   toggleLaunch: (u) => u('main.launch', (launch) => !launch),
   toggleReveal: (u) => u('main.reveal', (reveal) => !reveal),
   toggleShowLocalNameWithENS: (u) =>
@@ -119,9 +119,13 @@ module.exports = {
     })
   },
   setAccount: (u, account) => {
-    u('selected.current', (_) => account.id)
-    u('selected.minimized', (_) => false)
-    u('selected.open', (_) => true)
+    u('selected.current', () => account.id)
+    u('selected.minimized', () => false)
+    u('selected.open', () => true)
+    const accountMetaId = uuidv5(account.id, accountNS)
+    u('main.accountsMeta', accountMetaId, (accountMeta) => {
+      return { ...accountMeta, lastSelected: Date.now() }
+    })
   },
   setAccountSignerStatusOpen: (u, value) => {
     u('selected.signerStatusOpen', () => Boolean(value))
@@ -864,12 +868,12 @@ module.exports = {
     })
   },
   unsetAccount: (u) => {
-    u('selected.open', (_) => false)
-    u('selected.minimized', (_) => true)
-    u('selected.view', (_) => 'default')
-    u('selected.showAccounts', (_) => false)
+    u('selected.open', () => false)
+    u('selected.minimized', () => true)
+    u('selected.view', () => 'default')
+    u('selected.showAccounts', () => false)
     u('windows.panel.nav', () => [])
-    setTimeout((_) => {
+    setTimeout(() => {
       u('selected', (signer) => {
         signer.last = signer.current
         signer.current = ''

--- a/main/store/migrations/index.js
+++ b/main/store/migrations/index.js
@@ -911,7 +911,9 @@ module.exports = {
       .sort((a, b) => a - b)
       .forEach((version) => {
         if (parseInt(state.main._version) < version && version <= migrateToVersion) {
-          log.info(`Applying state migration: ${version}`)
+          if (process.env.NODE_ENV !== 'test') {
+            log.info(`Applying state migration: ${version}`)
+          }
           state = migrations[version](state)
           state.main._version = version
         }


### PR DESCRIPTION
* Storing the timestamp of last account selection as `accountMeta.lastSelected`
* Connection priority given to currently selected account
  * if the currently selected account has no permission, permission is requested for that account
  * other accounts are checked only if the currently selected account has explicitly denied permission
* In the case where there is no currently selected account or the currently selected account has explicitly denied permission, a given dapp connects to the most recently selected account which has permission for that dapp.

TODO:

- [ ] Document MM behaviour completely
- [ ] Finalise edge cases
- [ ] Tests