### PR TITLE
fix prod build

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
       "dependencies": {
         "@ethereumjs/common": "3.1.1",
         "@ethereumjs/tx": "4.1.1",
-        "@ethereumjs/util": "8.0.5",
+        "@ethereumjs/util": "8.0.3",
         "@ethersproject/contracts": "5.7.0",
         "@ethersproject/providers": "5.7.2",
         "@framelabs/pylon-client": "0.0.10",
@@ -133,8 +133,8 @@
         "wait-on": "7.0.1"
       },
       "engines": {
-        "electron": "22",
-        "node": ">= 16.15.0"
+        "electron": "23",
+        "node": ">= 18.12.1"
       }
     },
     "node_modules/@adobe/css-tools": {
@@ -2685,6 +2685,19 @@
         "crc-32": "^1.2.0"
       }
     },
+    "node_modules/@ethereumjs/common/node_modules/@ethereumjs/util": {
+      "version": "8.0.5",
+      "resolved": "https://registry.npmjs.org/@ethereumjs/util/-/util-8.0.5.tgz",
+      "integrity": "sha512-259rXKK3b3D8HRVdRmlOEi6QFvwxdt304hhrEAmpZhsj7ufXEOTIc9JRZPMnXatKjECokdLNBcDOFBeBSzAIaw==",
+      "dependencies": {
+        "@chainsafe/ssz": "0.9.4",
+        "@ethereumjs/rlp": "^4.0.1",
+        "ethereum-cryptography": "^1.1.2"
+      },
+      "engines": {
+        "node": ">=14"
+      }
+    },
     "node_modules/@ethereumjs/rlp": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/@ethereumjs/rlp/-/rlp-4.0.1.tgz",
@@ -2720,13 +2733,26 @@
         }
       }
     },
-    "node_modules/@ethereumjs/util": {
+    "node_modules/@ethereumjs/tx/node_modules/@ethereumjs/util": {
       "version": "8.0.5",
       "resolved": "https://registry.npmjs.org/@ethereumjs/util/-/util-8.0.5.tgz",
       "integrity": "sha512-259rXKK3b3D8HRVdRmlOEi6QFvwxdt304hhrEAmpZhsj7ufXEOTIc9JRZPMnXatKjECokdLNBcDOFBeBSzAIaw==",
       "dependencies": {
         "@chainsafe/ssz": "0.9.4",
         "@ethereumjs/rlp": "^4.0.1",
+        "ethereum-cryptography": "^1.1.2"
+      },
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/@ethereumjs/util": {
+      "version": "8.0.3",
+      "resolved": "https://registry.npmjs.org/@ethereumjs/util/-/util-8.0.3.tgz",
+      "integrity": "sha512-0apCbwc8xAaie6W7q6QyogfyRS2BMU816a8KwpnpRw9Qrc6Bws+l7J3LfCLMt2iL6Wi8CYb0B29AeIr2N4vHnw==",
+      "dependencies": {
+        "@ethereumjs/rlp": "^4.0.0-beta.2",
+        "async": "^3.2.4",
         "ethereum-cryptography": "^1.1.2"
       },
       "engines": {
@@ -27624,6 +27650,18 @@
       "requires": {
         "@ethereumjs/util": "^8.0.5",
         "crc-32": "^1.2.0"
+      },
+      "dependencies": {
+        "@ethereumjs/util": {
+          "version": "8.0.5",
+          "resolved": "https://registry.npmjs.org/@ethereumjs/util/-/util-8.0.5.tgz",
+          "integrity": "sha512-259rXKK3b3D8HRVdRmlOEi6QFvwxdt304hhrEAmpZhsj7ufXEOTIc9JRZPMnXatKjECokdLNBcDOFBeBSzAIaw==",
+          "requires": {
+            "@chainsafe/ssz": "0.9.4",
+            "@ethereumjs/rlp": "^4.0.1",
+            "ethereum-cryptography": "^1.1.2"
+          }
+        }
       }
     },
     "@ethereumjs/rlp": {
@@ -27642,15 +27680,27 @@
         "@ethereumjs/util": "^8.0.5",
         "@ethersproject/providers": "^5.7.2",
         "ethereum-cryptography": "^1.1.2"
+      },
+      "dependencies": {
+        "@ethereumjs/util": {
+          "version": "8.0.5",
+          "resolved": "https://registry.npmjs.org/@ethereumjs/util/-/util-8.0.5.tgz",
+          "integrity": "sha512-259rXKK3b3D8HRVdRmlOEi6QFvwxdt304hhrEAmpZhsj7ufXEOTIc9JRZPMnXatKjECokdLNBcDOFBeBSzAIaw==",
+          "requires": {
+            "@chainsafe/ssz": "0.9.4",
+            "@ethereumjs/rlp": "^4.0.1",
+            "ethereum-cryptography": "^1.1.2"
+          }
+        }
       }
     },
     "@ethereumjs/util": {
-      "version": "8.0.5",
-      "resolved": "https://registry.npmjs.org/@ethereumjs/util/-/util-8.0.5.tgz",
-      "integrity": "sha512-259rXKK3b3D8HRVdRmlOEi6QFvwxdt304hhrEAmpZhsj7ufXEOTIc9JRZPMnXatKjECokdLNBcDOFBeBSzAIaw==",
+      "version": "8.0.3",
+      "resolved": "https://registry.npmjs.org/@ethereumjs/util/-/util-8.0.3.tgz",
+      "integrity": "sha512-0apCbwc8xAaie6W7q6QyogfyRS2BMU816a8KwpnpRw9Qrc6Bws+l7J3LfCLMt2iL6Wi8CYb0B29AeIr2N4vHnw==",
       "requires": {
-        "@chainsafe/ssz": "0.9.4",
-        "@ethereumjs/rlp": "^4.0.1",
+        "@ethereumjs/rlp": "^4.0.0-beta.2",
+        "async": "^3.2.4",
         "ethereum-cryptography": "^1.1.2"
       }
     },

--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
   "dependencies": {
     "@ethereumjs/common": "3.1.1",
     "@ethereumjs/tx": "4.1.1",
-    "@ethereumjs/util": "8.0.5",
+    "@ethereumjs/util": "8.0.3",
     "@ethersproject/contracts": "5.7.0",
     "@ethersproject/providers": "5.7.2",
     "@framelabs/pylon-client": "0.0.10",


### PR DESCRIPTION
@ethereumjs/util v8.0.4 broke the prod build, can work around with the `wasm-unsafe-eval` CSP directive but probably better just to wait and see if it will be fixed in a later version.

https://github.com/ethereumjs/ethereumjs-monorepo/issues/2587

Reference:
https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/script-src#unsafe_webassembly_execution
https://github.com/WebAssembly/content-security-policy/issues/7



