### PR TITLE
Provider updates for better chain handling

### DIFF
--- a/main/provider/chains/index.ts
+++ b/main/provider/chains/index.ts
@@ -70,9 +70,7 @@ function getActiveChains(): RPC.GetEthereumChains.Chain[] {
   const colorway = storeApi.getColorway()
 
   return Object.values(chains)
-    .filter(
-      (chain) => chain.on && (chain.connection.primary.connected || chain.connection.secondary.connected)
-    )
+    .filter((chain) => chain.on)
     .sort((a, b) => a.id - b.id)
     .map((chain) => {
       const { id, explorer, name } = chain
@@ -86,6 +84,7 @@ function getActiveChains(): RPC.GetEthereumChains.Chain[] {
         chainId: id,
         networkId: id,
         name,
+        connected: chain.connection.primary.connected || chain.connection.secondary.connected,
         nativeCurrency: {
           name: currencyName,
           symbol,

--- a/main/provider/index.ts
+++ b/main/provider/index.ts
@@ -188,7 +188,7 @@ export class Provider extends EventEmitter {
     const chain = store('main.networks.ethereum', targetChain.id)
     const response = chain?.on
       ? { result: targetChain.id }
-      : { error: { message: !chain ? 'chain does not exist' : 'chain not enabled', code: -1 } }
+      : { error: { message: 'not connected', code: -1 } }
 
     res({ id: payload.id, jsonrpc: payload.jsonrpc, ...response })
   }

--- a/main/provider/index.ts
+++ b/main/provider/index.ts
@@ -197,7 +197,7 @@ export class Provider extends EventEmitter {
     const chain = store('main.networks.ethereum', targetChain.id)
     const response = chain?.on
       ? { result: intToHex(targetChain.id) }
-      : { error: { message: !chain ? 'chain does not exist' : 'chain not enabled', code: -1 } }
+      : { error: { message: 'not connected', code: -1 } }
 
     res({ id: payload.id, jsonrpc: payload.jsonrpc, ...response })
   }
@@ -862,9 +862,6 @@ export class Provider extends EventEmitter {
         const symbol = (tokenData.symbol || '').toUpperCase()
         const decimals = parseInt(tokenData.decimals || '1')
 
-        if (isNaN(chainId)) {
-          return resError('token chain is disabled', payload, cb)
-        }
         if (!address) {
           return resError('tokens must define an address', payload, cb)
         }
@@ -889,12 +886,6 @@ export class Provider extends EventEmitter {
           decimals,
           logoURI: tokenData.image || tokenData.logoURI || ''
         }
-
-        // const result = {
-        //   suggestedAssetMeta: {
-        //     asset: { token }
-        //   }
-        // }
 
         const handlerId = this.addRequestHandler(res)
 

--- a/main/provider/index.ts
+++ b/main/provider/index.ts
@@ -185,23 +185,19 @@ export class Provider extends EventEmitter {
   }
 
   getNetVersion(payload: RPCRequestPayload, res: RPCRequestCallback, targetChain: Chain) {
-    const connection = this.connection.connections[targetChain.type][targetChain.id]
-    const chainConnected = connection && (connection.primary?.connected || connection.secondary?.connected)
-
-    const response = chainConnected
-      ? { result: connection.chainId }
-      : { error: { message: 'not connected', code: 1 } }
+    const chain = store('main.networks.ethereum', targetChain.id)
+    const response = chain?.enabled
+      ? { result: targetChain.id }
+      : { error: { message: !chain ? 'chain not present' : 'chain not enabled', code: 1 } }
 
     res({ id: payload.id, jsonrpc: payload.jsonrpc, ...response })
   }
 
   getChainId(payload: RPCRequestPayload, res: RPCSuccessCallback, targetChain: Chain) {
-    const connection = this.connection.connections[targetChain.type][targetChain.id]
-    const chainConnected = connection.primary?.connected || connection.secondary?.connected
-
-    const response = chainConnected
+    const chain = store('main.networks.ethereum', targetChain.id)
+    const response = chain?.enabled
       ? { result: intToHex(targetChain.id) }
-      : { error: { message: 'not connected', code: 1 } }
+      : { error: { message: !chain ? 'chain not present' : 'chain not enabled', code: 1 } }
 
     res({ id: payload.id, jsonrpc: payload.jsonrpc, ...response })
   }

--- a/main/provider/index.ts
+++ b/main/provider/index.ts
@@ -186,18 +186,22 @@ export class Provider extends EventEmitter {
 
   getNetVersion(payload: RPCRequestPayload, res: RPCRequestCallback, targetChain: Chain) {
     const chain = store('main.networks.ethereum', targetChain.id)
-    const response = chain?.enabled
+    const response = chain?.on
       ? { result: targetChain.id }
       : { error: { message: !chain ? 'chain not present' : 'chain not enabled', code: 1 } }
+
+    console.log('netVersion response', response)
 
     res({ id: payload.id, jsonrpc: payload.jsonrpc, ...response })
   }
 
   getChainId(payload: RPCRequestPayload, res: RPCSuccessCallback, targetChain: Chain) {
     const chain = store('main.networks.ethereum', targetChain.id)
-    const response = chain?.enabled
+    const response = chain?.on
       ? { result: intToHex(targetChain.id) }
       : { error: { message: !chain ? 'chain not present' : 'chain not enabled', code: 1 } }
+
+    console.log('chainId response', response)
 
     res({ id: payload.id, jsonrpc: payload.jsonrpc, ...response })
   }
@@ -964,6 +968,8 @@ export class Provider extends EventEmitter {
     }
 
     const method = payload.method || ''
+
+    console.log('payload yo', payload)
 
     // method handlers that are not chain-specific can go here, before parsing the target chain
     if (method === 'eth_unsubscribe' && this.ifSubRemove(payload.params[0]))

--- a/test/main/provider/chains/index.test.js
+++ b/test/main/provider/chains/index.test.js
@@ -22,16 +22,6 @@ const chains = {
     connection: { primary: { connected: true }, secondary: { connected: false } },
     on: true
   },
-  4: {
-    name: 'Ethereum Testnet Rinkeby',
-    id: 4,
-    explorer: 'https://rinkeby.etherscan.io',
-    connection: {
-      primary: { status: 'connected', connected: true, on: true },
-      secondary: { status: 'standby', connected: false, on: true }
-    },
-    on: true
-  },
   5: {
     name: 'Ethereum Testnet Görli',
     id: 5,
@@ -55,13 +45,6 @@ const chainMeta = {
     nativeCurrency: ether,
     primaryColor: 'accent1'
   },
-  4: {
-    nativeCurrency: {
-      ...ether,
-      name: 'Rinkeby Ether'
-    },
-    primaryColor: 'accent2'
-  },
   5: {
     nativeCurrency: {
       ...ether,
@@ -78,7 +61,7 @@ beforeEach(() => {
 
 describe('#getActiveChains', () => {
   it('returns all chains that are active', () => {
-    expect(getActiveChains().map((chain) => chain.chainId)).toEqual([1, 4])
+    expect(getActiveChains().map((chain) => chain.chainId)).toEqual([1, 5])
   })
 
   it('returns an EVM chain object', () => {
@@ -103,7 +86,8 @@ describe('#getActiveChains', () => {
         wallet: {
           colors: [{ r: 0, g: 210, b: 190, hex: '#00d2be' }]
         }
-      }
+      },
+      connected: true
     })
   })
 })
@@ -154,28 +138,30 @@ describe('#createChainsObserver', () => {
           wallet: {
             colors: [{ r: 0, g: 210, b: 190, hex: '#00d2be' }]
           }
-        }
+        },
+        connected: true
       },
       {
-        chainId: 4,
-        networkId: 4,
-        name: 'Ethereum Testnet Rinkeby',
+        chainId: 5,
+        networkId: 5,
+        name: 'Ethereum Testnet Görli',
         icon: [{ url: 'https://assets.coingecko.com/coins/images/ethereum.png' }],
         nativeCurrency: {
-          name: 'Rinkeby Ether',
+          name: 'Görli Ether',
           symbol: 'ETH',
           decimals: 18
         },
         explorers: [
           {
-            url: 'https://rinkeby.etherscan.io'
+            url: 'https://goerli.etherscan.io'
           }
         ],
         external: {
           wallet: {
             colors: [{ r: 255, g: 153, b: 51, hex: '#ff9933' }]
           }
-        }
+        },
+        connected: false
       },
       {
         chainId: 10,
@@ -196,7 +182,8 @@ describe('#createChainsObserver', () => {
           wallet: {
             colors: [{ r: 246, g: 36, b: 35, hex: '#f62423' }]
           }
-        }
+        },
+        connected: true
       }
     ])
   })
@@ -215,11 +202,11 @@ describe('#createChainsObserver', () => {
     observer()
 
     const changedChains = handler.chainsChanged.mock.calls[0][0]
-    expect(changedChains.map((c) => c.chainId)).toEqual([1, 4, 10])
+    expect(changedChains.map((c) => c.chainId)).toEqual([1, 5, 10])
   })
 
   it('invokes the handler when a chain is removed', () => {
-    const { 4: rinkeby, ...remaining } = chains
+    const { 5: goerli, ...remaining } = chains
     setChains(remaining)
 
     observer()
@@ -239,16 +226,16 @@ describe('#createChainsObserver', () => {
     observer()
 
     const changedChains = handler.chainsChanged.mock.calls[0][0]
-    expect(changedChains.map((c) => c.chainId)).toEqual([1, 4, 137])
+    expect(changedChains.map((c) => c.chainId)).toEqual([1, 5, 137])
   })
 
   it('invokes the handler when a chain is deactivated', () => {
     const {
-      4: { ...rinkeby }
+      5: { ...goerli }
     } = chains
-    rinkeby.on = false
+    goerli.on = false
 
-    setChains({ ...chains, 4: rinkeby })
+    setChains({ ...chains, 5: goerli })
 
     observer()
 
@@ -258,37 +245,9 @@ describe('#createChainsObserver', () => {
 
   it('invokes the handler when a chain name changes', () => {
     const {
-      4: { ...rinkeby }
-    } = chains
-    rinkeby.name = 'Rink-a-Bee'
-
-    setChains({ ...chains, 4: rinkeby })
-
-    observer()
-
-    const changedChains = handler.chainsChanged.mock.calls[0][0]
-    expect(changedChains.map((c) => c.chainId)).toEqual([1, 4])
-  })
-
-  it('invokes the handler when a connected chain is disconnected', () => {
-    const {
-      4: { ...rinkeby }
-    } = chains
-    rinkeby.connection.primary.connected = false
-
-    setChains({ ...chains, 4: rinkeby })
-
-    observer()
-
-    const changedChains = handler.chainsChanged.mock.calls[0][0]
-    expect(changedChains.map((c) => c.chainId)).toEqual([1])
-  })
-
-  it('invokes the handler when a disconnected chain is connected', () => {
-    const {
       5: { ...goerli }
     } = chains
-    goerli.connection.primary.connected = true
+    goerli.name = 'Girly'
 
     setChains({ ...chains, 5: goerli })
 

--- a/test/main/provider/index.test.js
+++ b/test/main/provider/index.test.js
@@ -155,7 +155,7 @@ describe('#send', () => {
       store.set('main.networks.ethereum', 5, { id: 5, on: false })
 
       send({ method: 'eth_chainId', chainId: '0x5' }, (response) => {
-        expect(response.error.message).toBe('chain not enabled')
+        expect(response.error.message).toBe('not connected')
         expect(response.result).toBeUndefined()
       })
     })
@@ -457,7 +457,7 @@ describe('#send', () => {
 
       send(request, ({ error }) => {
         expect(error.code).toBe(-1)
-        expect(error.message).toMatch('chain does not exist')
+        expect(error.message).toMatch('not connected')
         expect(accountRequests).toHaveLength(0)
       })
     })
@@ -467,7 +467,7 @@ describe('#send', () => {
 
       send(request, ({ error }) => {
         expect(error.code).toBe(-1)
-        expect(error.message).toMatch('chain not enabled')
+        expect(error.message).toMatch('not connected')
         expect(accountRequests).toHaveLength(0)
       })
     })


### PR DESCRIPTION
* `getChainId` / `getNetVersion` - return chainId when enabled regardless of connection status
* `wallet_getEthereumChains` - return all enabled chains to the extension with connection status
* `wallet_watchAsset` - handle disabled and nonexistent chains
* tests updated