### PR TITLE
Allow v3 typedData through to Lattice

### DIFF
--- a/main/provider/index.ts
+++ b/main/provider/index.ts
@@ -679,10 +679,16 @@ export class Provider extends EventEmitter {
     if (
       version !== SignTypedDataVersion.V4 &&
       signerType &&
-      [SignerType.Ledger, SignerType.Lattice, SignerType.Trezor].includes(signerType)
+      [SignerType.Ledger, SignerType.Trezor].includes(signerType)
     ) {
       const signerName = capitalize(signerType)
       return resError(`${signerName} only supports eth_signTypedData_v4+`, payload, res)
+    }
+    if (
+      [SignTypedDataVersion.V3, SignTypedDataVersion.V4].includes(version) &&
+      signerType === SignerType.Lattice
+    ) {
+      return resError('Lattice only supports eth_signTypedData_v3+', payload, res)
     }
 
     const handlerId = this.addRequestHandler(res)


### PR DESCRIPTION
https://gridplus.github.io/gridplus-sdk/signing#sign_typed_data

We currently assume it is the same as trezor / ledger in only supporting v4.