### PR TITLE
forcing node version via .npmrc, ignoring intellij .idea folder

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,7 @@ dist
 compiled
 release
 test/.userData
+.idea
 .vscode
 .parcel-cache
 *.tsbuildinfo

--- a/.npmrc
+++ b/.npmrc
@@ -3,3 +3,7 @@
 # to build native dependencies so for the time being we provide the "--ignore-scripts"
 # CLI parameter on install instead
 ignore-scripts = false
+
+# If set to true, then npm will stubbornly refuse to install (or even consider installing)
+# any package that claims to not be compatible with the current Node.js version.
+engine-strict=true


### PR DESCRIPTION
`engine-strict=true`
If set to true, then npm will stubbornly refuse to install (or even consider installing) any package that claims to not be compatible with the current Node.js version.(https://docs.npmjs.com/cli/v7/using-npm/config#engine-strict)=true
`.idea`
The .idea/ folder is just the way that JetBrain's stores data. It's in IntelliJ and Webstorm. Should be ignored.