### PR TITLE
Fix Lattice Typed Data v3 logic

### DIFF
--- a/main/provider/index.ts
+++ b/main/provider/index.ts
@@ -685,7 +685,7 @@ export class Provider extends EventEmitter {
       return resError(`${signerName} only supports eth_signTypedData_v4+`, payload, res)
     }
     if (
-      [SignTypedDataVersion.V3, SignTypedDataVersion.V4].includes(version) &&
+      ![SignTypedDataVersion.V3, SignTypedDataVersion.V4].includes(version) &&
       signerType === SignerType.Lattice
     ) {
       return resError('Lattice only supports eth_signTypedData_v3+', payload, res)

--- a/test/main/provider/index.test.js
+++ b/test/main/provider/index.test.js
@@ -1368,9 +1368,9 @@ describe('#send', () => {
     })
 
     // these signers only support V4+
-    const HardwareSignersSupportingV4 = [SignerType.Ledger, SignerType.Trezor]
+    const HardwareSignersSupportingV4Only = [SignerType.Ledger, SignerType.Trezor]
 
-    HardwareSignersSupportingV4.forEach((signerType) => {
+    HardwareSignersSupportingV4Only.forEach((signerType) => {
       it(`does not submit a V3 request to a ${signerType}`, (done) => {
         accounts.get.mockImplementationOnce((addr) => {
           return addr === address ? { id: address, address, lastSignerType: signerType } : {}
@@ -1386,7 +1386,7 @@ describe('#send', () => {
       })
     })
 
-    it('should send a V3 request to a lattice', () => {
+    it('should submit a V3 request to a Lattice', () => {
       accounts.get.mockImplementationOnce((addr) => {
         return addr === address ? { id: address, address, lastSignerType: SignerType.Lattice } : {}
       })

--- a/test/main/provider/index.test.js
+++ b/test/main/provider/index.test.js
@@ -1368,9 +1368,9 @@ describe('#send', () => {
     })
 
     // these signers only support V4+
-    const hardwareSigners = [SignerType.Ledger, SignerType.Lattice, SignerType.Trezor]
+    const HardwareSignersSupportingV4 = [SignerType.Ledger, SignerType.Trezor]
 
-    hardwareSigners.forEach((signerType) => {
+    HardwareSignersSupportingV4.forEach((signerType) => {
       it(`does not submit a V3 request to a ${signerType}`, (done) => {
         accounts.get.mockImplementationOnce((addr) => {
           return addr === address ? { id: address, address, lastSignerType: signerType } : {}
@@ -1384,6 +1384,17 @@ describe('#send', () => {
           done()
         })
       })
+    })
+
+    it('should send a V3 request to a lattice', () => {
+      accounts.get.mockImplementationOnce((addr) => {
+        return addr === address ? { id: address, address, lastSignerType: SignerType.Lattice } : {}
+      })
+      const params = [address, typedData]
+
+      send({ method: 'eth_signTypedData_v3', params })
+
+      verifyRequest(SignTypedDataVersion.V3, typedData)
     })
 
     const unknownVersions = ['_v5', '_v1.1', 'v3']


### PR DESCRIPTION
Not sure how this slipped through but we're missing a `!` on the Lattice typed data error handling - the invalid version error should be displayed when the TD version is NOT 3 or 4.