### PR TITLE
Auto-bump version after release

### DIFF
--- a/.github/workflows/canary-prebuild.yml
+++ b/.github/workflows/canary-prebuild.yml
@@ -1,4 +1,4 @@
-name: Build and publish canary release
+name: Build and publish canary installer artifacts for all platforms
 
 on:
   push:

--- a/.github/workflows/compile-and-test.yml
+++ b/.github/workflows/compile-and-test.yml
@@ -3,7 +3,6 @@ name: Compile and run unit tests
 on:
   push:
     branches:
-      - 'beta.*'
       - 'canary'
       - 'develop'
   pull_request:

--- a/.github/workflows/post-publish-update-version.yml
+++ b/.github/workflows/post-publish-update-version.yml
@@ -1,0 +1,22 @@
+name: Update application version after release has been published
+
+on:
+  release:
+    types: [published]
+
+jobs:
+  bump_release:
+    runs-on: ubuntu-latest
+
+  steps:
+    - uses: actions/checkout@v3
+    - name: Update version
+      id: update-version
+      run: sh scripts/update-version.sh
+    - name: Commit & Push new version
+      run: |
+        git config user.name github-actions
+        git config user.email github-actions@github.com
+        git remote set-url origin https://x-access-token:${{ secrets.GITHUB_TOKEN }}@github.com/${{ github.repository }}
+        git commit -am "chore: update version"
+        git push

--- a/scripts/update-version.sh
+++ b/scripts/update-version.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+
+if [[ "$GITHUB_REF" =~ ^(.*)v[0-9]\.[0-9]\.[0-9](-canary\.[0-9])?$ ]]; then
+  VERSION=$(echo "$GITHUB_REF" | sed -r 's/(.*)v([0-9]\.[0-9]\.[0-9](-canary\.[0-9])?)/\2/g')
+  NEW_VERSION=$(echo "$VERSION" | awk -F. '{$NF = $NF + 1;} 1' OFS=.)
+
+  if [[ $VERSION == *'canary'* ]]; then
+    echo "Updating Canary to \"$NEW_VERSION\""
+    sed -i "s/\"version\": \"[[:digit:]].[[:digit:]].[[:digit:]]-canary.[[:digit:]]\"/\"version\": \"$NEW_VERSION\"/" package.json
+  else
+    echo "Updating Production to \"$NEW_VERSION\""
+    sed -i "s/\"version\": \"[[:digit:]].[[:digit:]].[[:digit:]]\"/\"version\": \"$NEW_VERSION\"/" package.json
+  fi
+else
+  echo "Could not update version for release tag \"$GITHUB_REF\""
+fi


### PR DESCRIPTION
Auto-bumping the Frame and Canary versions after a release of either one.

https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows
https://docs.github.com/en/webhooks-and-events/webhooks/webhook-events-and-payloads