### PR TITLE
Fix max fee handling for PulseChain & Fantom

### DIFF
--- a/app/tray/Account/Requests/TransactionRequest/AdjustFee/index.js
+++ b/app/tray/Account/Requests/TransactionRequest/AdjustFee/index.js
@@ -28,12 +28,6 @@ function bnToHex(bn) {
   return `0x${bn.toString(16)}`
 }
 
-function limitRange(bn, min = 0, max) {
-  if (max && bn.gt(max)) return BigNumber(max)
-  if (bn.lt(min)) return BigNumber(min)
-  return bn
-}
-
 function formatForInput(num, decimals, useWei = false) {
   if (!decimals) {
     return num.toString()
@@ -43,8 +37,6 @@ function formatForInput(num, decimals, useWei = false) {
 
 const totalFee = ({ gasPrice, baseFee, priorityFee, gasLimit }) =>
   gasPrice ? gasPrice.times(gasLimit) : baseFee.plus(priorityFee).times(gasLimit)
-
-const limitGasUnits = (bn) => limitRange(bn, 0)
 
 let submitTimeout = null
 
@@ -212,7 +204,7 @@ class TxFeeOverlay extends Component {
         rawBaseFee = maxTotalFee.div(gasLimit).decimalPlaces(0, BigNumber.ROUND_FLOOR).minus(priorityFee)
       }
 
-      return limitRange(rawBaseFee)
+      return BigNumber.maximum(0, rawBaseFee)
     }
 
     const displayPriorityFee = toDisplayFromWei(priorityFee)
@@ -223,7 +215,7 @@ class TxFeeOverlay extends Component {
         rawPriorityFee = maxTotalFee.div(gasLimit).decimalPlaces(0, BigNumber.ROUND_FLOOR).minus(baseFee)
       }
 
-      return limitRange(rawPriorityFee)
+      return BigNumber.maximum(0, rawPriorityFee)
     }
 
     const displayGasPrice = toDisplayFromWei(gasPrice)
@@ -234,7 +226,7 @@ class TxFeeOverlay extends Component {
         rawGasPrice = maxTotalFee.div(gasLimit).decimalPlaces(0, BigNumber.ROUND_FLOOR)
       }
 
-      return limitRange(rawGasPrice)
+      return BigNumber.maximum(0, rawGasPrice)
     }
 
     const displayGasLimit = gasLimit.toString()
@@ -247,7 +239,7 @@ class TxFeeOverlay extends Component {
         rawGasLimit = maxTotalFee.div(baseFee.plus(priorityFee)).decimalPlaces(0, BigNumber.ROUND_FLOOR)
       }
 
-      return limitGasUnits(rawGasLimit)
+      return BigNumber.maximum(0, rawGasLimit)
     }
 
     const receiveValueHandler = (value, name) => {

--- a/app/tray/Account/Requests/TransactionRequest/AdjustFee/index.js
+++ b/app/tray/Account/Requests/TransactionRequest/AdjustFee/index.js
@@ -4,6 +4,7 @@ import BigNumber from 'bignumber.js'
 
 import link from '../../../../../../resources/link'
 import { usesBaseFee } from '../../../../../../resources/domain/transaction'
+import { getMaxTotalFee } from '../../../../../../resources/gas'
 
 const numberFormat = { groupSeparator: '', decimalSeparator: '.' }
 
@@ -27,8 +28,8 @@ function bnToHex(bn) {
   return `0x${bn.toString(16)}`
 }
 
-function limitRange(bn, min = 0, max = 9999e9) {
-  if (bn.gt(max)) return BigNumber(max)
+function limitRange(bn, min = 0, max) {
+  if (max && bn.gt(max)) return BigNumber(max)
   if (bn.lt(min)) return BigNumber(min)
   return bn
 }
@@ -40,27 +41,10 @@ function formatForInput(num, decimals, useWei = false) {
   return useWei ? toDisplayFromWei(BigNumber(num)) : toDisplayFromGwei(BigNumber(num))
 }
 
-function getMaxTotalFee(tx = { chainId: '' }) {
-  const chainId = parseInt(tx.chainId)
-
-  // for ETH-based chains, the max fee should be 2 ETH
-  if ([1, 3, 4, 5, 6, 10, 42, 61, 62, 63, 69, 42161, 421611].includes(chainId)) {
-    return 2 * 1e18
-  }
-
-  // for Fantom, the max fee should be 250 FTM
-  if ([250, 4002].includes(chainId)) {
-    return 250 * 1e18
-  }
-
-  // for all other chains, default to 50 of the chain's currency
-  return 50 * 1e18
-}
-
 const totalFee = ({ gasPrice, baseFee, priorityFee, gasLimit }) =>
   gasPrice ? gasPrice.times(gasLimit) : baseFee.plus(priorityFee).times(gasLimit)
 
-const limitGasUnits = (bn) => limitRange(bn, 0, 12.5e6)
+const limitGasUnits = (bn) => limitRange(bn, 0)
 
 let submitTimeout = null
 

--- a/app/tray/Account/Requests/TransactionRequest/TxFee/index.js
+++ b/app/tray/Account/Requests/TransactionRequest/TxFee/index.js
@@ -43,12 +43,13 @@ const USDEstimateDisplay = ({ minFee, maxFee, nativeCurrency }) => {
   const { value: maxFeeValue, displayValue, approximationSymbol: maxFeeApproximation } = maxFee.fiat()
   const displayMaxFeeWarning = maxFeeValue > FEE_WARNING_THRESHOLD_USD
   const maxFeeIsUnknownValue = displayValue === '?'
+  const maxFeeIsZero = displayValue === '0.00'
 
   return (
     <div data-testid='usd-estimate-display' className='clusterTag'>
       <div className={`_txFeeValueDefault${displayMaxFeeWarning ? ' _txFeeValueDefaultWarn' : ''}`}>
         <span>{maxFeeIsUnknownValue ? '=' : '≈'}</span>
-        {maxFeeApproximation === '<' || maxFeeIsUnknownValue ? (
+        {maxFeeApproximation === '<' || maxFeeIsUnknownValue || maxFeeIsZero ? (
           <FeeDisplay fee={maxFee} />
         ) : (
           <FeeRange max={maxFee} min={minFee} />

--- a/app/tray/Account/Requests/TransactionRequest/TxFee/index.js
+++ b/app/tray/Account/Requests/TransactionRequest/TxFee/index.js
@@ -43,13 +43,12 @@ const USDEstimateDisplay = ({ minFee, maxFee, nativeCurrency }) => {
   const { value: maxFeeValue, displayValue, approximationSymbol: maxFeeApproximation } = maxFee.fiat()
   const displayMaxFeeWarning = maxFeeValue > FEE_WARNING_THRESHOLD_USD
   const maxFeeIsUnknownValue = displayValue === '?'
-  const maxFeeIsZero = displayValue === '0.00'
 
   return (
     <div data-testid='usd-estimate-display' className='clusterTag'>
       <div className={`_txFeeValueDefault${displayMaxFeeWarning ? ' _txFeeValueDefaultWarn' : ''}`}>
         <span>{maxFeeIsUnknownValue ? '=' : '≈'}</span>
-        {maxFeeApproximation === '<' || maxFeeIsUnknownValue || maxFeeIsZero ? (
+        {maxFeeApproximation === '<' || maxFeeIsUnknownValue ? (
           <FeeDisplay fee={maxFee} />
         ) : (
           <FeeRange max={maxFee} min={minFee} />

--- a/main/accounts/index.ts
+++ b/main/accounts/index.ts
@@ -11,7 +11,7 @@ import ExternalDataScanner, { DataScanner } from '../externalData'
 import Signer from '../signers/Signer'
 import { signerCompatibility as transactionCompatibility, SignerCompatibility } from '../transaction'
 
-import { weiIntToEthInt, hexToInt } from '../../resources/utils'
+import { weiIntToEthInt, hexToInt, minimumHex } from '../../resources/utils'
 import { accountPanelCrumb, signerPanelCrumb } from '../../resources/domain/nav'
 import { usesBaseFee, TransactionData, GasFeesSource } from '../../resources/domain/transaction'
 import { findUnavailableSigners, isSignerReady } from '../../resources/domain/signer'
@@ -926,13 +926,6 @@ export class Accounts extends EventEmitter {
     return !fee || isNaN(parseInt(fee, 16)) || parseInt(fee, 16) < 0
   }
 
-  private limitedHexValue(hexValue: string, min: number, max?: number) {
-    const value = parseInt(hexValue, 16)
-    if (value < min) return intToHex(min)
-    if (max && value > max) return intToHex(max)
-    return hexValue
-  }
-
   private txFeeUpdate(inputValue: string, handlerId: string, userUpdate: boolean) {
     // Check value
     if (this.invalidValue(inputValue)) throw new Error('txFeeUpdate, invalid input value')
@@ -1008,7 +1001,7 @@ export class Accounts extends EventEmitter {
     )
 
     // New value
-    const newBaseFee = parseInt(this.limitedHexValue(baseFee, 0), 16)
+    const newBaseFee = parseInt(minimumHex(baseFee, 0), 16)
 
     // No change
     if (newBaseFee === currentBaseFee) return
@@ -1045,7 +1038,7 @@ export class Accounts extends EventEmitter {
     )
 
     // New values
-    const newMaxPriorityFeePerGas = parseInt(this.limitedHexValue(priorityFee, 0), 16)
+    const newMaxPriorityFeePerGas = parseInt(minimumHex(priorityFee, 0), 16)
 
     // No change
     if (newMaxPriorityFeePerGas === maxPriorityFeePerGas) return
@@ -1081,7 +1074,7 @@ export class Accounts extends EventEmitter {
     const { currentAccount, gasLimit, gasPrice, txType } = this.txFeeUpdate(price, handlerId, userUpdate)
 
     // New values
-    const newGasPrice = parseInt(this.limitedHexValue(price, 0), 16)
+    const newGasPrice = parseInt(minimumHex(price, 0), 16)
 
     // No change
     if (newGasPrice === gasPrice) return
@@ -1110,7 +1103,7 @@ export class Accounts extends EventEmitter {
     const { currentAccount, maxFeePerGas, gasPrice, txType } = this.txFeeUpdate(limit, handlerId, userUpdate)
 
     // New values
-    const newGasLimit = parseInt(this.limitedHexValue(limit, 0), 16)
+    const newGasLimit = parseInt(minimumHex(limit, 0), 16)
 
     const txRequest = this.getTransactionRequest(currentAccount, handlerId)
     const tx = txRequest.data

--- a/main/provider/index.ts
+++ b/main/provider/index.ts
@@ -23,7 +23,7 @@ import Chains, { Chain } from '../chains'
 import reveal from '../reveal'
 import { getSignerType, Type as SignerType } from '../../resources/domain/signer'
 import { normalizeChainId, TransactionData } from '../../resources/domain/transaction'
-import { populate as populateTransaction, maxFee, classifyTransaction } from '../transaction'
+import { populate as populateTransaction, classifyTransaction } from '../transaction'
 import { capitalize } from '../../resources/utils'
 import { ApprovalType } from '../../resources/constants'
 import { createObserver as AssetsObserver, loadAssets } from './assets'
@@ -61,6 +61,7 @@ import { hasAddress } from '../../resources/domain/account'
 import { mapRequest } from '../requests'
 
 import type { Origin, Token } from '../store/state'
+import { getMaxTotalFee } from '../../resources/gas'
 
 interface RequiredApproval {
   type: ApprovalType
@@ -307,7 +308,7 @@ export class Provider extends EventEmitter {
     }
 
     const payload = req.payload
-    const maxTotalFee = maxFee(rawTx)
+    const maxTotalFee = getMaxTotalFee(rawTx)
 
     if (feeTotalOverMax(rawTx, maxTotalFee)) {
       const chainId = parseInt(rawTx.chainId)

--- a/main/provider/index.ts
+++ b/main/provider/index.ts
@@ -24,6 +24,7 @@ import reveal from '../reveal'
 import { getSignerType, Type as SignerType } from '../../resources/domain/signer'
 import { normalizeChainId, TransactionData } from '../../resources/domain/transaction'
 import { populate as populateTransaction, classifyTransaction } from '../transaction'
+import { getMaxTotalFee } from '../../resources/gas'
 import { capitalize } from '../../resources/utils'
 import { ApprovalType } from '../../resources/constants'
 import { createObserver as AssetsObserver, loadAssets } from './assets'
@@ -61,7 +62,6 @@ import { hasAddress } from '../../resources/domain/account'
 import { mapRequest } from '../requests'
 
 import type { Origin, Token } from '../store/state'
-import { getMaxTotalFee } from '../../resources/gas'
 
 interface RequiredApproval {
   type: ApprovalType

--- a/main/transaction/index.ts
+++ b/main/transaction/index.ts
@@ -74,23 +74,6 @@ function londonToLegacy(txData: TransactionData): TransactionData {
   return txData
 }
 
-function maxFee(rawTx: TransactionData) {
-  const chainId = parseInt(rawTx.chainId)
-
-  // for ETH-based chains, the max fee should be 2 ETH
-  if ([1, 3, 4, 5, 6, 10, 42, 61, 62, 63, 69, 42161, 421611].includes(chainId)) {
-    return 2 * 1e18
-  }
-
-  // for Fantom, the max fee should be 250 FTM
-  if ([250, 4002].includes(chainId)) {
-    return 250 * 1e18
-  }
-
-  // for all other chains, default to 50 of the chain's currency
-  return 50 * 1e18
-}
-
 function calculateMaxFeePerGas(maxBaseFee: string, maxPriorityFee: string) {
   const maxFeePerGas = BigNumber(maxPriorityFee).plus(maxBaseFee).toString(16)
   return addHexPrefix(maxFeePerGas)
@@ -191,4 +174,4 @@ function classifyTransaction({
   return TxClassification.NATIVE_TRANSFER
 }
 
-export { maxFee, populate, sign, signerCompatibility, londonToLegacy, classifyTransaction }
+export { populate, sign, signerCompatibility, londonToLegacy, classifyTransaction }

--- a/resources/gas/index.ts
+++ b/resources/gas/index.ts
@@ -1,0 +1,21 @@
+export function getMaxTotalFee(tx = { chainId: '' }) {
+  const chainId = parseInt(tx.chainId)
+
+  // for ETH-based chains, the max fee should be 2 ETH
+  if ([1, 3, 4, 5, 6, 10, 42, 61, 62, 63, 69, 42161, 421611].includes(chainId)) {
+    return 2 * 1e18
+  }
+
+  // for Fantom, the max fee should be 250 FTM
+  if ([250, 4002].includes(chainId)) {
+    return 250 * 1e18
+  }
+
+  // for PulseChain, the max fee should be 100000000000 PLS
+  if ([369, 940, 941, 942, 943].includes(chainId)) {
+    return 100000000000 * 1e18
+  }
+
+  // for all other chains, default to 50 of the chain's currency
+  return 50 * 1e18
+}

--- a/resources/gas/index.ts
+++ b/resources/gas/index.ts
@@ -6,9 +6,9 @@ export function getMaxTotalFee(tx = { chainId: '' }) {
     return 2 * 1e18
   }
 
-  // for Fantom, the max fee should be 250 FTM
+  // for Fantom, the max fee should be 14000 FTM
   if ([250, 4002].includes(chainId)) {
-    return 250 * 1e18
+    return 14000 * 1e18
   }
 
   // for PulseChain, the max fee should be 100000000000 PLS

--- a/resources/utils/index.ts
+++ b/resources/utils/index.ts
@@ -1,6 +1,7 @@
 import { randomInt } from 'crypto'
 import { addHexPrefix, intToHex, stripHexPrefix } from '@ethereumjs/util'
 import { getAddress as getChecksumAddress } from '@ethersproject/address'
+import BigNumber from 'bignumber.js'
 
 const weiToGwei = (wei: number) => wei / 1e9
 const weiToHex = (wei: number) => addHexPrefix(wei.toString(16))
@@ -89,7 +90,7 @@ function isNonZeroHex(hex: string) {
 }
 
 function minimumHex(hexValue: string, min = 0) {
-  return parseInt(hexValue, 16) < min ? intToHex(min) : hexValue
+  return addHexPrefix(BigNumber.maximum(hexValue, min).toString(16))
 }
 
 export {

--- a/resources/utils/index.ts
+++ b/resources/utils/index.ts
@@ -89,7 +89,7 @@ function isNonZeroHex(hex: string) {
 }
 
 function minimumHex(hexValue: string, min = 0) {
-  return parseInt(hexValue, 16) < intToHex(min) ? '0x0' : hexValue
+  return parseInt(hexValue, 16) < min ? intToHex(min) : hexValue
 }
 
 export {

--- a/resources/utils/index.ts
+++ b/resources/utils/index.ts
@@ -83,8 +83,13 @@ function getAddress(address: Address) {
     return lowerCaseAddress
   }
 }
+
 function isNonZeroHex(hex: string) {
   return !!hex && !['0x', '0x0'].includes(hex)
+}
+
+function minimumHex(hexValue: string, min = 0) {
+  return parseInt(hexValue, 16) < intToHex(min) ? '0x0' : hexValue
 }
 
 export {
@@ -107,5 +112,6 @@ export {
   getAddress,
   stripHexPrefix,
   matchFilter,
-  isNonZeroHex
+  isNonZeroHex,
+  minimumHex
 }

--- a/test/app/tray/Account/Requests/TransactionRequest/AdjustFee/index.test.js
+++ b/test/app/tray/Account/Requests/TransactionRequest/AdjustFee/index.test.js
@@ -185,10 +185,15 @@ describe('base fee input', () => {
     const { getBaseFeeInput, clearBaseFee, enterBaseFee } = setupComponent(req)
 
     await clearBaseFee()
-    await enterBaseFee('5600')
+    await enterBaseFee('660000')
 
-    expect(getBaseFeeInput().value).toBe('5333.333333333')
-    expect(link.rpc).toHaveBeenCalledWith('setBaseFee', gweiToHex(5333.333333333), '1', expect.any(Function))
+    expect(getBaseFeeInput().value).toBe('463666.666666666')
+    expect(link.rpc).toHaveBeenCalledWith(
+      'setBaseFee',
+      gweiToHex(463666.666666666),
+      '1',
+      expect.any(Function)
+    )
   })
 
   it('recalculates the base fee when the total fee exceeds the maximum allowed (PLS)', async () => {
@@ -349,12 +354,12 @@ describe('priority fee input', () => {
     const { getPriorityFeeInput, clearPriorityFee, enterPriorityFee } = setupComponent(req)
 
     await clearPriorityFee()
-    await enterPriorityFee('5600')
+    await enterPriorityFee('5600000')
 
-    expect(getPriorityFeeInput().value).toBe('5333.333333333')
+    expect(getPriorityFeeInput().value).toBe('463666.666666666')
     expect(link.rpc).toHaveBeenCalledWith(
       'setPriorityFee',
-      gweiToHex(5333.333333333),
+      gweiToHex(463666.666666666),
       '1',
       expect.any(Function)
     )
@@ -487,10 +492,10 @@ describe('gas limit input', () => {
     const { getGasLimitInput, clearGasLimit, enterGasLimit } = setupComponent(req)
 
     await clearGasLimit()
-    await enterGasLimit('11364000')
+    await enterGasLimit('11364000000')
 
-    expect(getGasLimitInput().value).toBe('11363636')
-    expect(link.rpc).toHaveBeenCalledWith('setGasLimit', '0xad6534', '1', expect.any(Function))
+    expect(getGasLimitInput().value).toBe('636363636')
+    expect(link.rpc).toHaveBeenCalledWith('setGasLimit', '0x25ee2374', '1', expect.any(Function))
   })
 
   it('recalculates the gas limit when the total fee exceeds the maximum allowed (PLS)', async () => {
@@ -667,10 +672,15 @@ describe('legacy transactions', () => {
       const { getGasPriceInput, clearGasPrice, enterGasPrice } = setupComponent(req)
 
       await clearGasPrice()
-      await enterGasPrice('85')
+      await enterGasPrice('85000')
 
-      expect(getGasPriceInput().value).toBe('83.333333333')
-      expect(link.rpc).toHaveBeenCalledWith('setGasPrice', gweiToHex(83.333333333), '1', expect.any(Function))
+      expect(getGasPriceInput().value).toBe('4666.666666666')
+      expect(link.rpc).toHaveBeenCalledWith(
+        'setGasPrice',
+        gweiToHex(4666.666666666),
+        '1',
+        expect.any(Function)
+      )
     })
 
     it('recalculates the gas price when the total fee exceeds the maximum allowed (PLS)', async () => {
@@ -721,10 +731,10 @@ describe('legacy transactions', () => {
       const { getGasLimitInput, clearGasLimit, enterGasLimit } = setupComponent(req)
 
       await clearGasLimit()
-      await enterGasLimit('2874000')
+      await enterGasLimit('2874000000')
 
-      expect(getGasLimitInput().value).toBe('2873563')
-      expect(link.rpc).toHaveBeenCalledWith('setGasLimit', '0x2bd8db', '1', expect.any(Function))
+      expect(getGasLimitInput().value).toBe('160919540')
+      expect(link.rpc).toHaveBeenCalledWith('setGasLimit', '0x9976ff4', '1', expect.any(Function))
     })
 
     it('recalculates the gas limit when the total fee exceeds the maximum allowed (PLS)', async () => {

--- a/test/main/transaction/index.test.js
+++ b/test/main/transaction/index.test.js
@@ -240,32 +240,6 @@ describe('#londonToLegacy', () => {
   })
 })
 
-describe('#maxFee', () => {
-  it('sets the max fee as 2 ETH on mainnet', () => {
-    const tx = {
-      chainId: addHexPrefix((1).toString(16))
-    }
-
-    expect(maxFee(tx)).toBe(2e18)
-  })
-
-  it('sets the max fee as 250 FTM on Fantom', () => {
-    const tx = {
-      chainId: addHexPrefix((250).toString(16))
-    }
-
-    expect(maxFee(tx)).toBe(250e18)
-  })
-
-  it('sets the max fee as 50 on other chains', () => {
-    const tx = {
-      chainId: addHexPrefix((255).toString(16))
-    }
-
-    expect(maxFee(tx)).toBe(5e19)
-  })
-})
-
 describe('#populate', () => {
   let gas
   let rawTx

--- a/test/resources/gas/index.test.js
+++ b/test/resources/gas/index.test.js
@@ -1,0 +1,36 @@
+import { addHexPrefix } from '@ethereumjs/util/dist'
+import { getMaxTotalFee } from '../../../resources/gas'
+
+describe('#getMaxTotalFee', () => {
+  it('sets the max fee as 2 ETH on mainnet', () => {
+    const tx = {
+      chainId: addHexPrefix((1).toString(16))
+    }
+
+    expect(getMaxTotalFee(tx)).toBe(2e18)
+  })
+
+  it('sets the max fee as 250 FTM on Fantom', () => {
+    const tx = {
+      chainId: addHexPrefix((250).toString(16))
+    }
+
+    expect(getMaxTotalFee(tx)).toBe(250e18)
+  })
+
+  it('sets the max fee as 100000000000 PLS on PulseChain', () => {
+    const tx = {
+      chainId: addHexPrefix((369).toString(16))
+    }
+
+    expect(getMaxTotalFee(tx)).toBe(1e29)
+  })
+
+  it('sets the max fee as 50 on other chains', () => {
+    const tx = {
+      chainId: addHexPrefix((255).toString(16))
+    }
+
+    expect(getMaxTotalFee(tx)).toBe(5e19)
+  })
+})

--- a/test/resources/gas/index.test.js
+++ b/test/resources/gas/index.test.js
@@ -10,12 +10,12 @@ describe('#getMaxTotalFee', () => {
     expect(getMaxTotalFee(tx)).toBe(2e18)
   })
 
-  it('sets the max fee as 250 FTM on Fantom', () => {
+  it('sets the max fee as 14000 FTM on Fantom', () => {
     const tx = {
       chainId: addHexPrefix((250).toString(16))
     }
 
-    expect(getMaxTotalFee(tx)).toBe(250e18)
+    expect(getMaxTotalFee(tx)).toBe(14000e18)
   })
 
   it('sets the max fee as 100000000000 PLS on PulseChain', () => {

--- a/test/resources/utils/index.test.js
+++ b/test/resources/utils/index.test.js
@@ -1,4 +1,4 @@
-import { matchFilter, getAddress } from '../../../resources/utils'
+import { matchFilter, getAddress, minimumHex } from '../../../resources/utils'
 
 describe('#matchFilter', () => {
   it('matches if the entire filter matches a single property', () => {
@@ -76,5 +76,19 @@ describe('#getAddress', () => {
     expect(getAddress('0x81aa3e376ea6e4b238a213324220C1a515031D12')).toBe(
       '0x81aA3e376ea6e4b238a213324220c1A515031D12'
     )
+  })
+})
+
+describe('#minimumHex', () => {
+  it('returns zero by default for an input less than zero', () => {
+    expect(minimumHex('-0xa')).toBe('0x0')
+  })
+
+  it('returns the specified minimum for an input less than the minimum', () => {
+    expect(minimumHex('0x16', 100)).toBe('0x64')
+  })
+
+  it('returns the given value if its greater than the minimum', () => {
+    expect(minimumHex('0x16', 10)).toBe('0x16')
   })
 })


### PR DESCRIPTION
- Fixed the PulseChain / FTM max fee issue
  - The upper limits on individual gas fields have been removed 
  - Now specifying max gas value limit of ~$5k USD in PLS for PulseChain transactions
  - Updated the max gas value limit for FTM to ~$5k USD in FTM