### PR TITLE
Enhance account selection logic and UI in tray menu

### DIFF
--- a/app/tray/Menu/index.js
+++ b/app/tray/Menu/index.js
@@ -24,6 +24,9 @@ class Menu extends React.Component {
     )
   }
   render() {
+    const accounts = this.store('main.accounts') || {}
+    const hasAccounts = Object.keys(accounts).length > 0
+
     return (
       <div className='panelMenu'>
         <div
@@ -40,22 +43,24 @@ class Menu extends React.Component {
         >
           {this.glitch(svg.sidebar(15), this.state.glitchOnSidebar)}
         </div>
-        <div
-          className={'panelMenuItem panelMenuItemSend'}
-          onClick={() => {
-            clearTimeout(this.clickTimer)
-            this.clickTimer = setTimeout(() => {
-              this.setState({ glitchOnSend: false })
-              link.send('*:addFrame', 'dappLauncher')
-              link.send('tray:action', 'setDash', { showing: false })
-            }, 50)
-          }}
-          onMouseEnter={() => this.setState({ glitchOnSend: true })}
-          onMouseOver={() => this.setState({ glitchOnSend: true })}
-          onMouseLeave={() => this.setState({ glitchOnSend: false })}
-        >
-          {this.glitch(svg.send(15), this.state.glitchOnSend)}
-        </div>
+        {hasAccounts && (
+          <div
+            className={'panelMenuItem panelMenuItemSend'}
+            onClick={() => {
+              clearTimeout(this.clickTimer)
+              this.clickTimer = setTimeout(() => {
+                this.setState({ glitchOnSend: false })
+                link.send('*:addFrame', 'dappLauncher')
+                link.send('tray:action', 'setDash', { showing: false })
+              }, 50)
+            }}
+            onMouseEnter={() => this.setState({ glitchOnSend: true })}
+            onMouseOver={() => this.setState({ glitchOnSend: true })}
+            onMouseLeave={() => this.setState({ glitchOnSend: false })}
+          >
+            {this.glitch(svg.send(15), this.state.glitchOnSend)}
+          </div>
+        )}
       </div>
     )
   }

--- a/main/externalData/index.ts
+++ b/main/externalData/index.ts
@@ -14,7 +14,18 @@ export interface DataScanner {
 }
 
 const storeApi = {
-  getActiveAddress: () => (store('selected.current') || '') as Address,
+  getActiveAddress: () => {
+    const current = store('selected.current') as string
+    if (current) return current as Address
+
+    const last = store('selected.last') as string
+    if (last) return last as Address
+
+    // Fallback to first available account
+    const accounts = (store('main.accounts') || {}) as Record<string, unknown>
+    const firstAccountId = Object.keys(accounts)[0]
+    return (firstAccountId || '') as Address
+  },
   getCustomTokens: () => (store('main.tokens.custom') || []) as Token[],
   getKnownTokens: (address?: Address) => ((address && store('main.tokens.known', address)) || []) as Token[],
   getConnectedNetworks: () => {

--- a/main/provider/assets/index.ts
+++ b/main/provider/assets/index.ts
@@ -30,11 +30,23 @@ const storeApi = {
   }
 }
 
+function getActiveAccountId(): string {
+  const current = store('selected.current') as string
+  if (current) return current
+
+  const last = store('selected.last') as string
+  if (last) return last
+
+  // Fallback to first available account
+  const accounts = (store('main.accounts') || {}) as Record<string, unknown>
+  return Object.keys(accounts)[0] || ''
+}
+
 function createObserver(handler: AssetsChangedHandler) {
   let debouncedAssets: RPC.GetAssets.Assets | null = null
 
   return function () {
-    const currentAccountId = store('selected.current') as string
+    const currentAccountId = getActiveAccountId()
 
     if (currentAccountId) {
       const assets = fetchAssets(currentAccountId)

--- a/main/store/state/index.ts
+++ b/main/store/state/index.ts
@@ -791,6 +791,7 @@ const initial = {
     minimized: true,
     open: false,
     current: '',
+    last: '',
     view: 'default',
     settings: {
       viewIndex: 0,

--- a/test/main/provider/assets/index.test.js
+++ b/test/main/provider/assets/index.test.js
@@ -113,12 +113,33 @@ describe('#createObserver', () => {
     })
   })
 
-  it('does not invoke the handler when no account is selected', () => {
+  it('does not invoke the handler when no account is available', () => {
     store.set('selected.current', undefined)
+    store.set('selected.last', undefined)
+    store.set('main.accounts', {})
 
     fireObserver()
 
     expect(handler.assetsChanged).not.toHaveBeenCalled()
+  })
+
+  it('falls back to last selected account when no current account', () => {
+    store.set('selected.current', undefined)
+    store.set('selected.last', account)
+
+    fireObserver()
+
+    expect(handler.assetsChanged).toHaveBeenCalledWith(account, expect.any(Object))
+  })
+
+  it('falls back to first account when no current or last selected', () => {
+    store.set('selected.current', undefined)
+    store.set('selected.last', undefined)
+    store.set('main.accounts', { [account]: { balances: { lastUpdated: new Date() } } })
+
+    fireObserver()
+
+    expect(handler.assetsChanged).toHaveBeenCalledWith(account, expect.any(Object))
   })
 
   it('does not invoke the handler when no assets are present', () => {


### PR DESCRIPTION
## Summary
- Fixed asset discovery hang when no account is expanded by implementing fallback to last selected or first available account
- Hide Send button in tray menu when no accounts exist
- Added `last` property to initial selected state for fallback support
- Added tests for account fallback behavior

## Changes
- `app/tray/Menu/index.js` - Hide Send button when no accounts exist
- `main/externalData/index.ts` - Updated `getActiveAddress()` with fallback hierarchy (current → last → first account)
- `main/provider/assets/index.ts` - Added `getActiveAccountId()` helper with same fallback logic
- `main/store/state/index.ts` - Added `last: ''` to initial selected state
- `test/main/provider/assets/index.test.js` - Added tests for fallback to last selected and first account

## Test plan
- [ ] Click Send without expanding any account → Assets should load
- [ ] Expand account, collapse it, click Send → Uses last expanded account
- [ ] Run `npm test`